### PR TITLE
Update valid_for_country? and invalid_for_country? to authorize downcase string and symbole

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     rake (10.0.3)
     rdoc (3.12)
       json (~> 1.4)
+    shoulda-context (1.1.2)
     slop (3.4.4)
     sprockets (2.2.2)
       hike (~> 1.2)
@@ -101,4 +102,5 @@ DEPENDENCIES
   phonelib!
   pry
   rails (>= 3.1.0)
+  shoulda-context
   sqlite3

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -123,11 +123,13 @@ module Phonelib
 
     # method checks if passed phone number is valid for provided country
     def valid_for_country?(phone_number, country)
+      country = country.to_s.upcase
       parse(phone_number, country).valid_for_country?(country)
     end
 
     # method checks if passed phone number is invalid for provided country
     def invalid_for_country?(phone_number, country)
+      country = country.to_s.upcase
       parse(phone_number, country).invalid_for_country?(country)
     end
 

--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -96,9 +96,10 @@ module Phonelib
     #
     # ==== Attributes
     #
-    # * +country+ - ISO code of country (2 letters) like 'US' for United States
+    # * +country+ - ISO code of country (2 letters) like 'US', 'us' or :us for United States
     #
     def valid_for_country?(country)
+      country = country.to_s.upcase
       @analyzed_data.select {|iso2, data| country == iso2 &&
           data[:valid].any? }.any?
     end
@@ -108,9 +109,10 @@ module Phonelib
     #
     # ==== Attributes
     #
-    # * +country+ - ISO code of country (2 letters) like 'US' for United States
+    # * +country+ - ISO code of country (2 letters) like 'US', 'us' or :us for United States
     #
     def invalid_for_country?(country)
+      country = country.to_s.upcase
       @analyzed_data.select {|iso2, data| country == iso2 &&
           data[:valid].any? }.empty?
     end

--- a/phonelib.gemspec
+++ b/phonelib.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "nokogiri"
   s.add_development_dependency "pry"
+  s.add_development_dependency 'shoulda-context'
 end

--- a/test/phonelib_test.rb
+++ b/test/phonelib_test.rb
@@ -1,105 +1,175 @@
 require 'test_helper'
 
-class PhonelibTest < ActiveSupport::TestCase
-  test "truth" do
+class PhonelibTest < Test::Unit::TestCase
+
+  should 'be a Module' do
     assert_kind_of Module, Phonelib
   end
 
-  test "returns phone object" do
-    assert Phonelib.parse('972541234567').is_a? Phonelib::Phone
+  context '.parse' do
+    setup { @phone = Phonelib.parse '9721234567' }
+
+    should 'return a Phone object' do
+      assert @phone.is_a? Phonelib::Phone #instance_of?
+    end
+
+    should 'be possible but not valid phone number' do
+      assert !@phone.valid?
+      assert @phone.possible?
+    end
   end
 
-  test "valid? with malformed phone number" do
-    assert !Phonelib.valid?('sdffsd')
+  context '.valid?' do
+    context 'with malformed phone number' do
+      should 'not be valid' do
+        assert !Phonelib.valid?('sdffsd')
+      end
+    end
+
+    context 'with valid phone number' do
+      should 'be valid' do
+        assert Phonelib.valid?('972541234567')
+      end
+    end
+
+    context 'with invalid phone number' do
+      should 'not be valid' do
+        assert !Phonelib.valid?('97254123')
+      end
+    end
   end
 
-  test "invalid? with malformed phone number" do
-    assert Phonelib.invalid?('sdffsd')
+  context '.invalid?' do
+    context 'with malformed phone number' do
+      should 'be valid' do
+        assert Phonelib.invalid?('sdffsd')
+      end
+    end
+
+    context 'with valid phone number' do
+      should 'not be valid' do
+        assert !Phonelib.invalid?('972541234567')
+      end
+    end
+
+    context 'with invalid phone number' do
+      should 'be valid' do
+        assert Phonelib.invalid?('97254123')
+      end
+    end
   end
 
-  test "valid? with valid phone number" do
-    assert Phonelib.valid? '972541234567'
+  context '.possible?' do
+    context 'with valid phone number' do
+      should 'be valid' do
+        assert Phonelib.possible? '972541234567'
+      end
+    end
+
+    context 'with invalid phone number' do
+      should 'not be valid' do
+        assert !Phonelib.possible?('97254123')
+      end
+    end
   end
 
-  test "invalid? with valid phone number" do
-    assert !Phonelib.invalid?('972541234567')
+  context '.impossible?' do
+    context 'with valid phone number' do
+      should 'not be valid' do
+        assert !Phonelib.impossible?('972541234567')
+      end
+    end
+
+    context 'with invalid phone number' do
+      should 'be valid' do
+        assert Phonelib.impossible?('97254123')
+      end
+    end
   end
 
-  test "possible? with valid phone number" do
-    assert Phonelib.possible? '972541234567'
+  context 'valid_for_country?' do
+    context 'with correct data' do
+      ['IL', :il].each do |country|
+        context "with #{country} as country" do
+          should 'be valid' do
+            assert Phonelib.valid_for_country?('972541234567', country)
+          end
+
+          context 'and national number' do
+            should 'be valid' do
+              assert Phonelib.valid_for_country?('0541234567', country)
+            end
+          end
+
+          context 'and without prefix' do
+            should 'be valid' do
+              assert Phonelib.valid_for_country?('541234567', country)
+            end
+          end
+        end
+      end
+    end
+
+    ['US', :us].each do |country|
+      context "with #{country} as country" do
+        context 'with incorrect data' do
+          should 'not be valid' do
+            assert !Phonelib.valid_for_country?('972541234567', country)
+          end
+
+          context 'and without prefix' do
+            should 'not be valid' do
+              assert !Phonelib.valid_for_country?('541234567', country)
+            end
+          end
+        end
+      end
+    end
   end
 
-  test "impossible? with valid phone number" do
-    assert !Phonelib.impossible?('972541234567')
+  context '.invalid_for_country?' do
+    context 'with correct data' do
+      ['IL', :il].each do |country|
+        context "with #{country} as country" do
+          should 'not be invalid' do
+            assert !Phonelib.invalid_for_country?('972541234567', country)
+          end
+        end
+      end
+    end
+
+    context 'with incorrect data' do
+      ['US', :us].each do |country|
+        context "with #{country} as country" do
+          should 'be invalid' do
+            assert Phonelib.invalid_for_country?('972541234567', country)
+          end
+        end
+      end
+    end
   end
 
-  test "valid? with invalid phone number" do
-    assert !Phonelib.valid?('97254123')
+  context '#international' do
+    should 'return right formatting' do
+      phone = Phonelib.parse('972541234567')
+      assert_equal '+972 54-123-4567', phone.international
+    end
+
+    should 'return sanitized when number invalid but possible' do
+      phone = Phonelib.parse('9721234567')
+      assert_equal '+9721234567', phone.international
+    end
   end
 
-  test "invalid? with invalid phone number" do
-    assert Phonelib.invalid?('97254123')
-  end
+  context '#national' do
+    should 'return right formatting' do
+      phone = Phonelib.parse('972541234567')
+      assert_equal '054-123-4567', phone.national
+    end
 
-  test "possible? with invalid phone number" do
-    assert !Phonelib.possible?('97254123')
-  end
-
-  test "impossible? with invalid phone number" do
-    assert Phonelib.impossible?('97254123')
-  end
-
-  test "possible but not valid phone number" do
-    phone = Phonelib.parse('9721234567')
-    assert !phone.valid?
-    assert phone.possible?
-  end
-
-  test "valid_for_country? with correct data" do
-    assert Phonelib.valid_for_country?('972541234567', 'IL')
-  end
-  
-  test "valid_for_country? with correct data and national number" do
-    assert Phonelib.valid_for_country?('0541234567', 'IL')
-  end
-  
-  test "valid_for_country? with correct data and without prefix" do
-    assert Phonelib.valid_for_country?('541234567', 'IL')
-  end
-  
-  test "valid_for_country? with fake data and without prefix" do
-    assert !Phonelib.valid_for_country?('541234567', 'US')
-  end
-
-  test "invalid_for_country? with correct data" do
-    assert !Phonelib.invalid_for_country?('972541234567', 'IL')
-  end
-
-  test "invalid_for_country? with incorrect data" do
-    assert Phonelib.invalid_for_country?('972541234567', 'US')
-  end
-
-  test "valid_for_country? with incorrect data" do
-    assert !Phonelib.valid_for_country?('972541234567', 'US')
-  end
-
-  test "international method returns with right formatting" do
-    phone = Phonelib.parse('972541234567')
-    assert phone.international == '+972 54-123-4567'
-  end
-
-  test "national method returns right formatting" do
-    phone = Phonelib.parse('972541234567')
-    assert phone.national == '054-123-4567'
-  end
-
-  test "international method returns sanitized when number invalid but possible" do
-    phone = Phonelib.parse('9721234567')
-    assert phone.international == '+9721234567'
-  end
-
-  test "national method returns sanitized national when number invalid but possible" do
-    phone = Phonelib.parse('9721234567')
-    assert phone.national == '1234567'
+    should 'return sanitized national when number invalid but possible' do
+      phone = Phonelib.parse('9721234567')
+      assert_equal '1234567', phone.national
+    end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,7 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require 'shoulda-context'
 require File.expand_path("../dummy/config/environment.rb",  __FILE__)
 require "rails/test_help"
 


### PR DESCRIPTION
But first I re-author Phonelib tests with shoulda-context to have more readable tests.
