### PR TITLE
Parsing international-formatted numbers (with '+')

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -135,7 +135,7 @@ module Phonelib
 
     private
     def convert_phone_to_e164(phone, prefix, national_prefix)
-      return phone if phone.start_with?(prefix)
+      return phone if phone.gsub('+','').start_with?(prefix)
       if !!national_prefix && phone.start_with?(national_prefix)
         phone = phone[1..phone.length]
       end

--- a/test/phonelib_test.rb
+++ b/test/phonelib_test.rb
@@ -17,6 +17,13 @@ class PhonelibTest < Test::Unit::TestCase
       assert !@phone.valid?
       assert @phone.possible?
     end
+
+    context 'with international formatting' do
+      setup { @phone = Phonelib.parse('+1 (972) 123-4567', 'US') }
+      should 'return exact original' do
+        assert_equal '+1 (972) 123-4567', @phone.original
+      end
+    end
   end
 
   context '.valid?' do


### PR DESCRIPTION
Fix for the issue where parsing an international-formatted number would add the country code before the '+'
