### PR TITLE
Update whitespace handling in data parsing task

### DIFF
--- a/data/phone_data.yml
+++ b/data/phone_data.yml
@@ -4,7 +4,7 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-467]\d{3}'
+      :nationalNumberPattern: '[2-467]\d{3}'
       :possibleNumberPattern: \d{4}
     :fixedLine:
       :nationalNumberPattern: (?:[267]\d|3[0-5]|4[4-69])\d{2}
@@ -21,11 +21,11 @@
       :nationalNumberPattern: (?:[346-9]|180)\d{5}
       :possibleNumberPattern: \d{6,8}
     :fixedLine:
-      :nationalNumberPattern: ! '[78]\d{5}'
+      :nationalNumberPattern: '[78]\d{5}'
       :possibleNumberPattern: \d{6}
       :exampleNumber: '712345'
     :mobile:
-      :nationalNumberPattern: ! '[346]\d{5}'
+      :nationalNumberPattern: '[346]\d{5}'
       :possibleNumberPattern: \d{6}
       :exampleNumber: '312345'
     :tollFree:
@@ -38,11 +38,11 @@
       :exampleNumber: '912345'
   :formats:
   - :pattern: (\d{3})(\d{3})
-    :leadingDigits: ! '[346-9]'
-    :format: $1$2
+    :leadingDigits: '[346-9]'
+    :format: $1 $2
   - :pattern: (180[02])(\d{4})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
 - :id: AE
   :countryCode: '971'
   :internationalPrefix: '00'
@@ -50,10 +50,10 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-79]\d{7,8}|800\d{2,9}'
+      :nationalNumberPattern: '[2-79]\d{7,8}|800\d{2,9}'
       :possibleNumberPattern: \d{5,12}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-4679][2-8]\d{6}'
+      :nationalNumberPattern: '[2-4679][2-8]\d{6}'
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '22345678'
     :mobile:
@@ -78,19 +78,19 @@
       :exampleNumber: '600212345'
   :formats:
   - :pattern: ([2-4679])(\d{3})(\d{4})
-    :leadingDigits: ! '[2-4679][2-8]'
-    :format: $1$2$3
+    :leadingDigits: '[2-4679][2-8]'
+    :format: $1 $2 $3
   - :pattern: (5[0256])(\d{3})(\d{4})
     :leadingDigits: '5'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([479]00)(\d)(\d{5})
     :nationalPrefixFormattingRule: $FG
-    :leadingDigits: ! '[479]0'
-    :format: $1$2$3
+    :leadingDigits: '[479]0'
+    :format: $1 $2 $3
   - :pattern: ([68]00)(\d{2,9})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: 60|8
-    :format: $1$2
+    :format: $1 $2
 - :id: AF
   :countryCode: '93'
   :internationalPrefix: '00'
@@ -98,7 +98,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-7]\d{8}'
+      :nationalNumberPattern: '[2-7]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:[25][0-8]|[34][0-4]|6[0-5])[2-9]\d{6}
@@ -109,7 +109,7 @@
       :exampleNumber: '701234567'
   :formats:
   - :pattern: ([2-7]\d)(\d{3})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: AG
   :countryCode: '1'
   :leadingDigits: '268'
@@ -117,7 +117,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2589]\d{9}'
+      :nationalNumberPattern: '[2589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 268(?:4(?:6[0-38]|84)|56[0-2])\d{4}
@@ -153,7 +153,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2589]\d{9}'
+      :nationalNumberPattern: '[2589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 2644(?:6[12]|9[78])\d{4}
@@ -182,7 +182,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57]\d{7}|6\d{8}|8\d{5,7}|9\d{5}'
+      :nationalNumberPattern: '[2-57]\d{7}|6\d{8}|8\d{5,7}|9\d{5}'
       :possibleNumberPattern: \d{5,9}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:[168][1-9]|[247]\d|9[1-7])|3(?:1[1-3]|[2-6]\d|[79][1-8]|8[1-9])|4\d{2}|5(?:1[1-4]|[2-578]\d|6[1-5]|9[1-7])|8(?:[19][1-5]|[2-6]\d|[78][1-7]))\d{5}
@@ -211,16 +211,16 @@
   :formats:
   - :pattern: (4)(\d{3})(\d{4})
     :leadingDigits: 4[0-6]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6[6-9])(\d{3})(\d{4})
     :leadingDigits: '6'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[2358][2-5]|4[7-9]'
-    :format: $1$2$3
+    :leadingDigits: '[2358][2-5]|4[7-9]'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3,5})
-    :leadingDigits: ! '[235][16-9]|8[016-9]|[79]'
-    :format: $1$2
+    :leadingDigits: '[235][16-9]|8[016-9]|[79]'
+    :format: $1 $2
 - :id: AM
   :countryCode: '374'
   :internationalPrefix: '00'
@@ -228,7 +228,7 @@
   :nationalPrefixFormattingRule: ($NP$FG)
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{7}'
+      :nationalNumberPattern: '[1-9]\d{7}'
       :possibleNumberPattern: \d{5,8}
     :fixedLine:
       :nationalNumberPattern: (?:1[01]\d|2(?:2[2-46]|3[1-8]|4[2-69]|5[2-7]|6[1-9]|8[1-7])|3[12]2|47\d)\d{5}
@@ -256,24 +256,24 @@
   :formats:
   - :pattern: (\d{2})(\d{6})
     :leadingDigits: 1|47
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{6})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[5-7]|9[1-9]'
-    :format: $1$2
+    :leadingDigits: '[5-7]|9[1-9]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{5})
-    :leadingDigits: ! '[23]'
-    :format: $1$2
+    :leadingDigits: '[23]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{2})(\d{3})
     :nationalPrefixFormattingRule: $NP $FG
     :leadingDigits: 8|90
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: AO
   :countryCode: '244'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[29]\d{8}'
+      :nationalNumberPattern: '[29]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 2\d(?:[26-9]\d|\d[26-9])\d{5}
@@ -283,7 +283,7 @@
       :exampleNumber: '923123456'
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: AR
   :countryCode: '54'
   :internationalPrefix: '00'
@@ -294,7 +294,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-368]\d{9}|9\d{10}'
+      :nationalNumberPattern: '[1-368]\d{9}|9\d{10}'
       :possibleNumberPattern: \d{6,11}
     :noInternationalDialling:
       :nationalNumberPattern: 810\d{7}
@@ -322,43 +322,43 @@
       :exampleNumber: '8101234567'
   :formats:
   - :pattern: ([68]\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[68]'
+    :leadingDigits: '[68]'
     :format: $1-$2-$3
   - :pattern: (9)(11)(\d{4})(\d{4})
     :leadingDigits: '911'
-    :format: $215-$3-$4
-    :intlFormat: $1$2$3-$4
+    :format: $2 15-$3-$4
+    :intlFormat: $1 $2 $3-$4
   - :pattern: (9)(\d{3})(\d{3})(\d{4})
     :comment: ''
     :leadingDigits: 9(?:2(?:2[013]|3[067]|49|6[01346]|80|9(?:[17-9]|4[13479]))|3(?:36|4[12358]|5(?:[18]|3[014-689])|6[24]|7[069]|8(?:[01]|3[013469]|5[0-39]|7[0-2459]|8[0-49])))
-    :format: $215-$3-$4
-    :intlFormat: $1$2$3-$4
+    :format: $2 15-$3-$4
+    :intlFormat: $1 $2 $3-$4
   - :pattern: (9)(\d{4})(\d{3})(\d{3})
     :comment: ''
     :leadingDigits: 9(?:3(?:537|8(?:73|88)))
-    :format: $215-$3-$4
-    :intlFormat: $1$2$3-$4
+    :format: $2 15-$3-$4
+    :intlFormat: $1 $2 $3-$4
   - :pattern: (9)(\d{4})(\d{2})(\d{4})
     :leadingDigits: 9[23]
-    :format: $215-$3-$4
-    :intlFormat: $1$2$3-$4
+    :format: $2 15-$3-$4
+    :intlFormat: $1 $2 $3-$4
   - :pattern: (11)(\d{4})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :leadingDigits: '1'
-    :format: $1$2-$3
+    :format: $1 $2-$3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :leadingDigits: 2(?:2[013]|3[067]|49|6[01346]|80|9(?:[17-9]|4[13479]))|3(?:36|4[12358]|5(?:[18]|3[0-689])|6[24]|7[069]|8(?:[01]|3[013469]|5[0-39]|7[0-2459]|8[0-49]))
     :comment: ''
-    :format: $1$2-$3
+    :format: $1 $2-$3
   - :pattern: (\d{4})(\d{3})(\d{3})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :leadingDigits: 3(?:537|8(?:73|88))
-    :format: $1$2-$3
+    :format: $1 $2-$3
   - :pattern: (\d{4})(\d{2})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
-    :leadingDigits: ! '[23]'
-    :format: $1$2-$3
+    :leadingDigits: '[23]'
+    :format: $1 $2-$3
   - :pattern: (\d{3})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: 1[012]|911
@@ -376,7 +376,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{9}'
+      :nationalNumberPattern: '[5689]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 6846(?:22|33|44|55|77|88|9[19])\d{4}
@@ -405,7 +405,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{3,12}'
+      :nationalNumberPattern: '[1-9]\d{3,12}'
       :possibleNumberPattern: \d{3,13}
     :fixedLine:
       :nationalNumberPattern: 1\d{3,12}|(?:2(?:1[467]|2[13-8]|5[2357]|6[1-46-8]|7[1-8]|8[124-7]|9[1458])|3(?:1[1-8]|3[23568]|4[5-7]|5[1378]|6[1-38]|8[3-68])|4(?:2[1-8]|35|63|7[1368]|8[2457])|5(?:12|2[1-8]|3[357]|4[147]|5[12578]|6[37])|6(?:13|2[1-47]|4[1-35-8]|5[468]|62)|7(?:2[1-8]|3[25]|4[13478]|5[68]|6[16-8]|7[1-6]|9[45]))\d{3,10}
@@ -437,22 +437,22 @@
   :formats:
   - :pattern: (1)(\d{3,12})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (5\d)(\d{3,5})
     :leadingDigits: 5[079]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (5\d)(\d{3})(\d{3,4})
     :leadingDigits: 5[079]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (5\d)(\d{4})(\d{4,7})
     :leadingDigits: 5[079]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3,10})
     :leadingDigits: 316|46|51|732|6(?:44|5[0-3579]|[6-9])|7(?:1|[28]0)|[89]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{4})(\d{3,9})
     :leadingDigits: 2|3(?:1[1-578]|[3-8])|4[2378]|5[2-6]|6(?:[12]|4[1-35-9]|5[468])|7(?:2[1-8]|35|4[1-8]|[5-79])
-    :format: $1$2
+    :format: $1 $2
 - :id: AU
   :countryCode: '61'
   :mainCountryForCode: 'true'
@@ -462,14 +462,14 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-578]\d{5,9}'
+      :nationalNumberPattern: '[1-578]\d{5,9}'
       :possibleNumberPattern: \d{6,10}
     :noInternationalDialling:
       :nationalNumberPattern: 1(?:3(?:\d{4}|00\d{6})|80(?:0\d{6}|2\d{3}))
       :possibleNumberPattern: \d{6,10}
       :exampleNumber: '1300123456'
     :fixedLine:
-      :nationalNumberPattern: ! '[237]\d{8}|8(?:[68]\d{3}|7[0-69]\d{2}|9(?:[02-9]\d{2}|1(?:[0-57-9]\d|6[0135-9])))\d{4}'
+      :nationalNumberPattern: '[237]\d{8}|8(?:[68]\d{3}|7[0-69]\d{2}|9(?:[02-9]\d{2}|1(?:[0-57-9]\d|6[0135-9])))\d{4}'
       :possibleNumberPattern: \d{8,9}
       :exampleNumber: '212345678'
     :mobile:
@@ -503,42 +503,42 @@
   :formats:
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: ([2378])(\d{4})(\d{4})
-    :leadingDigits: ! '[2378]'
-    :format: $1$2$3
+    :leadingDigits: '[2378]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{3})(\d{3})
-    :leadingDigits: ! '[45]|14'
-    :format: $1$2$3
+    :leadingDigits: '[45]|14'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (16)(\d{3})(\d{2,4})
     :leadingDigits: '16'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1[389]\d{2})(\d{3})(\d{3})
     :leadingDigits: 1(?:[38]00|90)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (180)(2\d{3})
     :leadingDigits: '1802'
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: $FG
     :pattern: (19\d)(\d{3})
     :leadingDigits: 19[13]
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: $FG
     :pattern: (19\d{2})(\d{4})
     :leadingDigits: 19[67]
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: $FG
     :pattern: (13)(\d{2})(\d{2})
     :leadingDigits: 13[1-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: AW
   :countryCode: '297'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[25-9]\d{6}'
+      :nationalNumberPattern: '[25-9]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 5(?:2\d|8[1-9])\d{4}
@@ -557,7 +557,7 @@
       :exampleNumber: '5011234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: AX
   :countryCode: '358'
   :internationalPrefix: 00|99[049]
@@ -565,10 +565,10 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[135]\d{5,9}|[27]\d{4,9}|4\d{5,10}|6\d{7,8}|8\d{6,9}'
+      :nationalNumberPattern: '[135]\d{5,9}|[27]\d{4,9}|4\d{5,10}|6\d{7,8}|8\d{6,9}'
       :possibleNumberPattern: \d{5,12}
     :noInternationalDialling:
-      :nationalNumberPattern: ! '[13]00\d{3,7}|2(?:0(?:0\d{3,7}|2[023]\d{1,6}|9[89]\d{1,6}))|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
+      :nationalNumberPattern: '[13]00\d{3,7}|2(?:0(?:0\d{3,7}|2[023]\d{1,6}|9[89]\d{1,6}))|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
       :possibleNumberPattern: \d{5,10}
       :exampleNumber: '100123'
     :fixedLine:
@@ -584,11 +584,11 @@
       :possibleNumberPattern: \d{7,10}
       :exampleNumber: '8001234567'
     :premiumRate:
-      :nationalNumberPattern: ! '[67]00\d{5,6}'
+      :nationalNumberPattern: '[67]00\d{5,6}'
       :possibleNumberPattern: \d{8,9}
       :exampleNumber: '600123456'
     :uan:
-      :nationalNumberPattern: ! '[13]0\d{4,8}|2(?:0(?:[016-8]\d{3,7}|[2-59]\d{2,7})|9\d{4,8})|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
+      :nationalNumberPattern: '[13]0\d{4,8}|2(?:0(?:[016-8]\d{3,7}|[2-59]\d{2,7})|9\d{4,8})|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
       :possibleNumberPattern: \d{5,10}
       :exampleNumber: '10112345'
 - :id: AZ
@@ -599,7 +599,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{8}'
+      :nationalNumberPattern: '[1-9]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:1[28]\d|2(?:02|1[24]|2[2-4]|33|[45]2|6[23])|365)\d{6}
@@ -619,15 +619,15 @@
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{2})(\d{2})
     :leadingDigits: (?:1[28]|2(?:[45]2|[0-36])|365)
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{3})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[4-8]'
-    :format: $1$2$3$4
+    :leadingDigits: '[4-8]'
+    :format: $1 $2 $3 $4
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: '9'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: BA
   :countryCode: '387'
   :internationalPrefix: '00'
@@ -636,7 +636,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3-9]\d{7,8}'
+      :nationalNumberPattern: '[3-9]\d{7,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:[35]\d|49)\d{6}
@@ -664,14 +664,14 @@
       :exampleNumber: '70223456'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[3-5]'
-    :format: $1$2-$3
+    :leadingDigits: '[3-5]'
+    :format: $1 $2-$3
   - :pattern: (\d{2})(\d{3})(\d{3})
     :leadingDigits: 6[1-356]|[7-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{3})
     :leadingDigits: 6[047]
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: BB
   :countryCode: '1'
   :leadingDigits: '246'
@@ -679,7 +679,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2589]\d{9}'
+      :nationalNumberPattern: '[2589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 246[2-9]\d{6}
@@ -708,7 +708,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-79]\d{5,9}|1\d{9}|8[0-7]\d{4,8}'
+      :nationalNumberPattern: '[2-79]\d{5,9}|1\d{9}|8[0-7]\d{4,8}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: 2(?:7(?:1[0-267]|2[0-289]|3[0-29]|[46][01]|5[1-3]|7[017]|91)|8(?:0[125]|[139][1-6]|2[0157-9]|6[1-35]|7[1-5]|8[1-8])|9(?:0[0-2]|1[1-4]|2[568]|3[3-6]|5[5-7]|6[0167]|7[15]|8[016-8]))\d{4}|3(?:12?[5-7]\d{2}|0(?:2(?:[025-79]\d|[348]\d{1,2})|3(?:[2-4]\d|[56]\d?))|2(?:1\d{2}|2(?:[12]\d|[35]\d{1,2}|4\d?))|3(?:1\d{2}|2(?:[2356]\d|4\d{1,2}))|4(?:1\d{2}|2(?:2\d{1,2}|[47]|5\d{2}))|5(?:1\d{2}|29)|[67]1\d{2}|8(?:1\d{2}|2(?:2\d{2}|3|4\d))|)\d{3}|4(?:0(?:2(?:[09]\d|7)|33\d{2})|1\d{3}|2(?:1\d{2}|2(?:[25]\d?|[348]\d|[67]\d{1,2}))|3(?:1\d{2}(?:\d{2})?|2(?:[045]\d|[236-9]\d{1,2})|32\d{2})|4(?:[18]\d{2}|2(?:[2-46]\d{2}|3)|5[25]\d{2})|5(?:1\d{2}|2(?:3\d|5))|6(?:[18]\d{2}|2(?:3(?:\d{2})?|[46]\d{1,2}|5\d{2}|7\d)|5(?:3\d?|4\d|[57]\d{1,2}|6\d{2}|8))|71\d{2}|8(?:[18]\d{2}|23\d{2}|54\d{2})|9(?:[18]\d{2}|2[2-5]\d{2}|53\d{1,2}))\d{3}|5(?:02[03489]\d{2}|1\d{2}|2(?:1\d{2}|2(?:2(?:\d{2})?|[457]\d{2}))|3(?:1\d{2}|2(?:[37](?:\d{2})?|[569]\d{2}))|4(?:1\d{2}|2[46]\d{2})|5(?:1\d{2}|26\d{1,2})|6(?:[18]\d{2}|2|53\d{2})|7(?:1|24)\d{2}|8(?:1|26)\d{2}|91\d{2})\d{3}|6(?:0(?:1\d{2}|2(?:3\d{2}|4\d{1,2}))|2(?:2[2-5]\d{2}|5(?:[3-5]\d{2}|7)|8\d{2})|3(?:1|2[3478])\d{2}|4(?:1|2[34])\d{2}|5(?:1|2[47])\d{2}|6(?:[18]\d{2}|6(?:2(?:2\d|[34]\d{2})|5(?:[24]\d{2}|3\d|5\d{1,2})))|72[2-5]\d{2}|8(?:1\d{2}|2[2-5]\d{2})|9(?:1\d{2}|2[2-6]\d{2}))\d{3}|7(?:(?:02|[3-589]1|6[12]|72[24])\d{2}|21\d{3}|32)\d{3}|8(?:(?:4[12]|[5-7]2|1\d?)|(?:0|3[12]|[5-7]1|217)\d)\d{4}|9(?:[35]1|(?:[024]2|81)\d|(?:1|[24]1)\d{2})\d{3}
@@ -731,13 +731,13 @@
     :leadingDigits: '2'
     :format: $1-$2
   - :pattern: (\d{2})(\d{4,6})
-    :leadingDigits: ! '[3-79]1'
+    :leadingDigits: '[3-79]1'
     :format: $1-$2
   - :pattern: (\d{4})(\d{3,6})
     :leadingDigits: 1|3(?:0|[2-58]2)|4(?:0|[25]2|3[23]|[4689][25])|5(?:[02-578]2|6[25])|6(?:[0347-9]2|[26][25])|7[02-9]2|8(?:[023][23]|[4-7]2)|9(?:[02][23]|[458]2|6[016])
     :format: $1-$2
   - :pattern: (\d{3})(\d{3,7})
-    :leadingDigits: ! '[3-79][2-9]|8'
+    :leadingDigits: '[3-79][2-9]|8'
     :format: $1-$2
 - :id: BE
   :countryCode: '32'
@@ -747,7 +747,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{7,8}'
+      :nationalNumberPattern: '[1-9]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
       :nationalNumberPattern: (?:1[0-69]|[23][2-8]|[49][23]|5\d|6[013-57-9]|71)\d{6}|8(?:0[1-9]|[1-79]\d)\d{5}
@@ -772,22 +772,22 @@
   :formats:
   - :pattern: (4[6-9]\d)(\d{2})(\d{2})(\d{2})
     :leadingDigits: 4[6-9]
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: ([2-49])(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[23]|[49][23]'
-    :format: $1$2$3$4
+    :leadingDigits: '[23]|[49][23]'
+    :format: $1 $2 $3 $4
   - :pattern: ([15-8]\d)(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[156]|7[0178]|8(?:0[1-9]|[1-79])'
-    :format: $1$2$3$4
+    :leadingDigits: '[156]|7[0178]|8(?:0[1-9]|[1-79])'
+    :format: $1 $2 $3 $4
   - :pattern: ([89]\d{2})(\d{2})(\d{3})
     :leadingDigits: (?:80|9)0
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: BF
   :countryCode: '226'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24-7]\d{7}'
+      :nationalNumberPattern: '[24-7]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:20(?:49|5[23]|9[016-9])|40(?:4[56]|5[4-6]|7[0179])|50[34]\d)\d{4}
@@ -797,7 +797,7 @@
       :exampleNumber: '70123456'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: BG
   :countryCode: '359'
   :internationalPrefix: '00'
@@ -806,7 +806,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[23567]\d{5,7}|[489]\d{6,8}'
+      :nationalNumberPattern: '[23567]\d{5,7}|[489]\d{6,8}'
       :possibleNumberPattern: \d{5,9}
     :fixedLine:
       :nationalNumberPattern: 2(?:[0-8]\d{5,6}|9\d{4,6})|(?:[36]\d|5[1-9]|8[1-6]|9[1-7])\d{5,6}|(?:4(?:[124-7]\d|3[1-6])|7(?:0[1-9]|[1-9]\d))\d{4,5}
@@ -830,32 +830,32 @@
   :formats:
   - :pattern: (2)(\d{5})
     :leadingDigits: '29'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (2)(\d{3})(\d{3,4})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{4})
     :leadingDigits: 43[124-7]|70[1-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{2})
     :leadingDigits: 43[124-7]|70[1-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{3})
-    :leadingDigits: ! '[78]00'
-    :format: $1$2$3
+    :leadingDigits: '[78]00'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{2,3})
-    :leadingDigits: ! '[356]|4[124-7]|7[1-9]|8[1-6]|9[1-7]'
-    :format: $1$2$3
+    :leadingDigits: '[356]|4[124-7]|7[1-9]|8[1-6]|9[1-7]'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3,4})
     :leadingDigits: 48|8[7-9]|9[08]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: BH
   :countryCode: '973'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[136-9]\d{7}'
+      :nationalNumberPattern: '[136-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:3[13-6]|6[0156]|7\d)\d|6(?:1[16]\d|6(?:0\d|3[12]|44|88)|9(?:6[69]|9[6-9]))|7(?:7\d{2}|178))\d{4}
@@ -874,13 +874,13 @@
       :exampleNumber: '84123456'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: BI
   :countryCode: '257'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[27]\d{7}'
+      :nationalNumberPattern: '[27]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 22(?:2[0-7]|[3-5]0)\d{4}
@@ -890,13 +890,13 @@
       :exampleNumber: '79561234'
   :formats:
   - :pattern: ([27]\d)(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: BJ
   :countryCode: '229'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2689]\d{7}|7\d{3}'
+      :nationalNumberPattern: '[2689]\d{7}|7\d{3}'
       :possibleNumberPattern: \d{4,8}
     :fixedLine:
       :nationalNumberPattern: 2(?:02|1[037]|2[45]|3[68])\d{5}
@@ -920,14 +920,14 @@
       :exampleNumber: '81123456'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: BL
   :countryCode: '590'
   :internationalPrefix: '00'
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[56]\d{8}'
+      :nationalNumberPattern: '[56]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 590(?:2[7-9]|5[12]|87)\d{4}
@@ -942,7 +942,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[4589]\d{9}'
+      :nationalNumberPattern: '[4589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 441(?:2(?:02|23|61|[3479]\d)|[46]\d{2}|5(?:4\d|60|89)|824)\d{4}
@@ -968,17 +968,17 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-578]\d{6}'
+      :nationalNumberPattern: '[2-578]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-5]\d{6}'
+      :nationalNumberPattern: '[2-5]\d{6}'
       :exampleNumber: '2345678'
     :mobile:
-      :nationalNumberPattern: ! '[78]\d{6}'
+      :nationalNumberPattern: '[78]\d{6}'
       :exampleNumber: '7123456'
   :formats:
   - :pattern: ([2-578]\d{2})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: BO
   :countryCode: '591'
   :internationalPrefix: 00(1\d)?
@@ -987,29 +987,29 @@
   :carrierCodeFormattingRule: $NP$CC$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[23467]\d{7}'
+      :nationalNumberPattern: '[23467]\d{7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:2\d{2}|5(?:11|[258]\d|9[67])|6(?:12|2\d|9[34])|8(?:2[34]|39|62))|3(?:3\d{2}|4(?:6\d|8[24])|8(?:25|42|5[257]|86|9[25])|9(?:2\d|3[234]|4[248]|5[24]|6[2-6]|7\d))|4(?:4\d{2}|6(?:11|[24689]\d|72)))\d{4}
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '22123456'
     :mobile:
-      :nationalNumberPattern: ! '[67]\d{7}'
+      :nationalNumberPattern: '[67]\d{7}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '71234567'
   :formats:
   - :pattern: ([234])(\d{7})
-    :leadingDigits: ! '[234]'
-    :format: $1$2
+    :leadingDigits: '[234]'
+    :format: $1 $2
   - :pattern: ([67]\d{7})
-    :leadingDigits: ! '[67]'
+    :leadingDigits: '[67]'
     :format: $1
 - :id: BQ
   :countryCode: '599'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[347]\d{6}'
+      :nationalNumberPattern: '[347]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: (?:318[023]|416[0239]|7(?:1[578]|50)\d)\d{3}
@@ -1026,10 +1026,10 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-46-9]\d{7,10}|5\d{8,9}'
+      :nationalNumberPattern: '[1-46-9]\d{7,10}|5\d{8,9}'
       :possibleNumberPattern: \d{8,11}
     :noInternationalDialling:
-      :nationalNumberPattern: ! '[34]00\d{5}'
+      :nationalNumberPattern: '[34]00\d{5}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '40041234'
     :fixedLine:
@@ -1043,16 +1043,16 @@
       :nationalNumberPattern: 800\d{6,7}
       :exampleNumber: '800123456'
     :premiumRate:
-      :nationalNumberPattern: ! '[359]00\d{6,7}'
+      :nationalNumberPattern: '[359]00\d{6,7}'
       :exampleNumber: '300123456'
     :sharedCost:
-      :nationalNumberPattern: ! '[34]00\d{5}'
+      :nationalNumberPattern: '[34]00\d{5}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '40041234'
   :formats:
   - :nationalPrefixFormattingRule: $FG
     :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[2-9](?:[1-9]|0[1-9])'
+    :leadingDigits: '[2-9](?:[1-9]|0[1-9])'
     :format: $1-$2
     :intlFormat: NA
   - :nationalPrefixFormattingRule: $FG
@@ -1069,19 +1069,19 @@
     :pattern: (\d{2})(\d{5})(\d{4})
     :carrierCodeFormattingRule: $NP $CC ($FG)
     :leadingDigits: (?:1[1-9]|2[12478])9
-    :format: $1$2-$3
+    :format: $1 $2-$3
   - :nationalPrefixFormattingRule: ($FG)
     :pattern: (\d{2})(\d{4})(\d{4})
     :carrierCodeFormattingRule: $NP $CC ($FG)
-    :leadingDigits: ! '[1-9][1-9]'
-    :format: $1$2-$3
+    :leadingDigits: '[1-9][1-9]'
+    :format: $1 $2-$3
   - :pattern: ([34]00\d)(\d{4})
-    :leadingDigits: ! '[34]00'
+    :leadingDigits: '[34]00'
     :format: $1-$2
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([3589]00)(\d{2,3})(\d{4})
-    :leadingDigits: ! '[3589]00'
-    :format: $1$2$3
+    :leadingDigits: '[3589]00'
+    :format: $1 $2 $3
 - :id: BS
   :countryCode: '1'
   :leadingDigits: '242'
@@ -1089,7 +1089,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2589]\d{9}'
+      :nationalNumberPattern: '[2589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 242(?:3(?:02|[236][1-9]|4[0-24-9]|5[0-68]|7[3467]|8[0-4]|9[2-467])|461|502|6(?:12|7[67]|8[78]|9[89])|702)\d{4}
@@ -1115,29 +1115,29 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-8]\d{6,7}'
+      :nationalNumberPattern: '[1-8]\d{6,7}'
       :possibleNumberPattern: \d{6,8}
     :fixedLine:
       :nationalNumberPattern: (?:2[3-6]|[34][5-7]|5[236]|6[2-46]|7[246]|8[2-4])\d{5}
       :possibleNumberPattern: \d{6,7}
       :exampleNumber: '2345678'
     :mobile:
-      :nationalNumberPattern: ! '[17]7\d{6}'
+      :nationalNumberPattern: '[17]7\d{6}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '17123456'
   :formats:
   - :pattern: ([17]7)(\d{2})(\d{2})(\d{2})
     :leadingDigits: 1|77
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: ([2-8])(\d{3})(\d{3})
-    :leadingDigits: ! '[2-68]|7[246]'
-    :format: $1$2$3
+    :leadingDigits: '[2-68]|7[246]'
+    :format: $1 $2 $3
 - :id: BW
   :countryCode: '267'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-79]\d{6,7}'
+      :nationalNumberPattern: '[2-79]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:4[0-48]|6[0-24]|9[0578])|3(?:1[0235-9]|55|6\d|7[01]|9[0-57])|4(?:6[03]|7[1267]|9[0-5])|5(?:3[0389]|4[0489]|7[1-47]|88|9[0-49])|6(?:2[1-35]|5[149]|8[067]))\d{4}
@@ -1157,14 +1157,14 @@
       :exampleNumber: '79101234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[2-6]'
-    :format: $1$2
+    :leadingDigits: '[2-6]'
+    :format: $1 $2
   - :pattern: (7\d)(\d{3})(\d{3})
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (90)(\d{5})
     :leadingDigits: '9'
-    :format: $1$2
+    :format: $1 $2
 - :id: BY
   :countryCode: '375'
   :preferredInternationalPrefix: 8~10
@@ -1174,7 +1174,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-4]\d{8}|[89]\d{9,10}'
+      :nationalNumberPattern: '[1-4]\d{8}|[89]\d{9,10}'
       :possibleNumberPattern: \d{7,11}
     :noInternationalDialling:
       :nationalNumberPattern: 8(?:[01]|20)\d{8}|902\d{7}
@@ -1199,26 +1199,26 @@
   :formats:
   - :nationalPrefixFormattingRule: $NP 0$FG
     :pattern: ([1-4]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[1-4]'
-    :format: $1$2$3
+    :leadingDigits: '[1-4]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP $FG
     :pattern: ([89]\d{2})(\d{3})(\d{4})
     :leadingDigits: 8[01]|9
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP $FG
     :pattern: (8\d{2})(\d{4})(\d{4})
     :leadingDigits: '82'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: BZ
   :countryCode: '501'
   :internationalPrefix: '00'
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{6}|0\d{10}'
+      :nationalNumberPattern: '[2-8]\d{6}|0\d{10}'
       :possibleNumberPattern: \d{7}(?:\d{4})?
     :fixedLine:
-      :nationalNumberPattern: ! '[234578][02]\d{5}'
+      :nationalNumberPattern: '[234578][02]\d{5}'
       :possibleNumberPattern: \d{7}
       :exampleNumber: '2221234'
     :mobile:
@@ -1231,7 +1231,7 @@
       :exampleNumber: 08001234123
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[2-8]'
+    :leadingDigits: '[2-8]'
     :comment: ''
     :format: $1-$2
   - :pattern: (0)(800)(\d{4})(\d{3})
@@ -1244,7 +1244,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{9}|3\d{6}'
+      :nationalNumberPattern: '[2-9]\d{9}|3\d{6}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: (?:2(?:04|[23]6|[48]9|50)|3(?:06|43|65)|4(?:03|1[68]|3[178]|50)|5(?:06|1[49]|79|8[17])|6(?:0[04]|13|39|47)|7(?:0[59]|78|80)|8(?:[06]7|19|73)|90[25])[2-9]\d{6}|310\d{4}
@@ -1270,7 +1270,7 @@
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1458]\d{5,9}'
+      :nationalNumberPattern: '[1458]\d{5,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: 89162\d{4}
@@ -1303,7 +1303,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-6]\d{6}|[18]\d{6,8}|9\d{8}'
+      :nationalNumberPattern: '[2-6]\d{6}|[18]\d{6,8}|9\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: 1(?:2\d{7}|\d{6})|[2-6]\d{6}
@@ -1314,22 +1314,22 @@
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{4})
     :leadingDigits: '12'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([89]\d{2})(\d{3})(\d{3})
     :leadingDigits: 8[0-2459]|9
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{3})
     :leadingDigits: '88'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{5})
-    :leadingDigits: ! '[1-6]'
-    :format: $1$2
+    :leadingDigits: '[1-6]'
+    :format: $1 $2
 - :id: CF
   :countryCode: '236'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[278]\d{7}'
+      :nationalNumberPattern: '[278]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2[12]\d{6}
@@ -1342,14 +1342,14 @@
       :exampleNumber: '87761234'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: CG
   :countryCode: '242'
   :internationalPrefix: '00'
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[028]\d{8}'
+      :nationalNumberPattern: '[028]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 222[1-589]\d{5}
@@ -1362,11 +1362,11 @@
       :exampleNumber: '800123456'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[02]'
-    :format: $1$2$3
+    :leadingDigits: '[02]'
+    :format: $1 $2 $3
   - :pattern: (\d)(\d{4})(\d{4})
     :leadingDigits: '8'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: CH
   :countryCode: '41'
   :internationalPrefix: '00'
@@ -1375,7 +1375,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{8}|860\d{9}'
+      :nationalNumberPattern: '[2-9]\d{8}|860\d{9}'
       :possibleNumberPattern: \d{9}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: (?:2[12467]|3[1-4]|4[134]|5[256]|6[12]|[7-9]1)\d{7}
@@ -1415,21 +1415,21 @@
       :exampleNumber: '860123456789'
   :formats:
   - :pattern: ([2-9]\d)(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[2-7]|[89]1'
-    :format: $1$2$3$4
+    :leadingDigits: '[2-7]|[89]1'
+    :format: $1 $2 $3 $4
   - :pattern: ([89]\d{2})(\d{3})(\d{3})
     :leadingDigits: 8[047]|90
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{3})(\d{2})(\d{2})
     :leadingDigits: '860'
-    :format: $1$2$3$4$5
+    :format: $1 $2 $3 $4 $5
 - :id: CI
   :countryCode: '225'
   :internationalPrefix: '00'
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[02-6]\d{7}'
+      :nationalNumberPattern: '[02-6]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:0[023]|1[02357]|[23][045]|4[03-5])|3(?:0[06]|1[069]|[2-4][07]|5[09]|6[08]))\d{5}
@@ -1439,13 +1439,13 @@
       :exampleNumber: '01234567'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: CK
   :countryCode: '682'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57]\d{4}'
+      :nationalNumberPattern: '[2-57]\d{4}'
       :possibleNumberPattern: \d{5}
     :fixedLine:
       :nationalNumberPattern: (?:2\d|3[13-7]|4[1-5])\d{3}
@@ -1455,7 +1455,7 @@
       :exampleNumber: '71234'
   :formats:
   - :pattern: (\d{2})(\d{3})
-    :format: $1$2
+    :format: $1 $2
 - :id: CL
   :countryCode: '56'
   :internationalPrefix: (?:0|1(?:1[0-69]|2[0-57]|5[13-58]|69|7[0167]|8[018]))0
@@ -1496,33 +1496,33 @@
     :nationalPrefixFormattingRule: ($FG)
     :carrierCodeFormattingRule: $CC ($FG)
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2,3})(\d{4})
     :nationalPrefixFormattingRule: ($FG)
     :carrierCodeFormattingRule: $CC ($FG)
-    :leadingDigits: ! '[357]|4[1-35]|6[13-57]'
-    :format: $1$2$3
+    :leadingDigits: '[357]|4[1-35]|6[13-57]'
+    :format: $1 $2 $3
   - :pattern: (9)([5-9]\d{3})(\d{4})
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (44)(\d{3})(\d{4})
     :leadingDigits: '44'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: ([68]00)(\d{3})(\d{3,4})
     :leadingDigits: 60|8
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (600)(\d{3})(\d{2})(\d{3})
     :leadingDigits: '60'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1230)(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (\d{4,5})
-    :leadingDigits: ! '[1-9]'
+    :leadingDigits: '[1-9]'
     :format: $1
     :intlFormat: NA
 - :id: CM
@@ -1530,13 +1530,13 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2357-9]\d{7}'
+      :nationalNumberPattern: '[2357-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:22|33)\d{6}
       :exampleNumber: '22123456'
     :mobile:
-      :nationalNumberPattern: ! '[579]\d{7}'
+      :nationalNumberPattern: '[579]\d{7}'
       :exampleNumber: '71234567'
     :tollFree:
       :nationalNumberPattern: 800\d{5}
@@ -1546,11 +1546,11 @@
       :exampleNumber: '88012345'
   :formats:
   - :pattern: ([2357-9]\d)(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[23579]|88'
-    :format: $1$2$3$4
+    :leadingDigits: '[23579]|88'
+    :format: $1 $2 $3 $4
   - :pattern: (800)(\d{2})(\d{3})
     :leadingDigits: '80'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: CN
   :countryCode: '86'
   :internationalPrefix: (1[1279]\d{3})?00
@@ -1594,10 +1594,10 @@
     :nationalPrefixOptionalWhenFormatting: 'true'
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: 80[2678]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([48]00)(\d{3})(\d{4})
-    :leadingDigits: ! '[48]00'
-    :format: $1$2$3
+    :leadingDigits: '[48]00'
+    :format: $1 $2 $3
   - :pattern: (\d{5,6})
     :leadingDigits: 100|95
     :format: $1
@@ -1606,48 +1606,48 @@
     :pattern: (\d{2})(\d{5,6})
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: (?:10|2\d)(?:100|95)
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{5,6})
     :carrierCodeFormattingRule: $CC $FG
-    :leadingDigits: ! '[3-9]\d{2}(?:10|95)'
-    :format: $1$2
+    :leadingDigits: '[3-9]\d{2}(?:10|95)'
+    :format: $1 $2
   - :pattern: (\d{3,4})(\d{4})
-    :leadingDigits: ! '[2-9]'
-    :format: $1$2
+    :leadingDigits: '[2-9]'
+    :format: $1 $2
     :intlFormat: NA
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (21)(\d{4})(\d{4,6})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: '21'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([12]\d)(\d{4})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: 10(?:[1-79]|8(?:[1-9]|0[1-9]))|2[02-9]
     :comment: ''
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{4})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: 3(?:11|7[179])|4(?:[15]1|3[12])|5(?:1|2[37]|3[12]|51|7[13-79]|9[15])|7(?:31|5[457]|6[09]|91)|8(?:71|98)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{3})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: 3(?:1[02-9]|35|49|5|7[02-68]|9[1-68])|4(?:1[02-9]|2[179]|[35][2-9]|6[4789]|7\d|8[23])|5(?:3[03-9]|4[36]|5[02-9]|6[1-46]|7[028]|80|9[2-46-9])|6(?:3[1-5]|6[0238]|9[12])|7(?:01|[1579]|2[248]|3[04-9]|4[3-6]|6[2368])|8(?:1[236-8]|2[5-7]|3|5[1-9]|7[02-9]|8[3678]|9[1-7])|9(?:0[1-3689]|1[1-79]|[379]|4[13]|5[1-5])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1[3-58]\d)(\d{4})(\d{4})
     :carrierCodeFormattingRule: $CC $FG
     :leadingDigits: 1[3-58]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (10800)(\d{3})(\d{4})
     :leadingDigits: '10800'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: CO
   :countryCode: '57'
   :internationalPrefix: 00[579]|#555|#999
@@ -1659,7 +1659,7 @@
       :nationalNumberPattern: (?:[13]\d{0,3}|[24-8])\d{7}
       :possibleNumberPattern: \d{7,11}
     :fixedLine:
-      :nationalNumberPattern: ! '[124-8][2-9]\d{6}'
+      :nationalNumberPattern: '[124-8][2-9]\d{6}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '12345678'
     :mobile:
@@ -1679,16 +1679,16 @@
     :carrierCodeFormattingRule: $NP$CC $FG
     :nationalPrefixFormattingRule: ($FG)
     :leadingDigits: 1(?:8[2-9]|9(?:09|[1-3])|[2-7])|[24-8]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{7})
     :carrierCodeFormattingRule: $NP$CC $FG
     :leadingDigits: '3'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (1)(\d{3})(\d{7})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: 1(?:800|9(?:0[01]|4[78]))
     :format: $1-$2-$3
-    :intlFormat: $1$2$3
+    :intlFormat: $1 $2 $3
 - :id: CR
   :countryCode: '506'
   :internationalPrefix: '00'
@@ -1696,7 +1696,7 @@
   :carrierCodeFormattingRule: $CC$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24-9]\d{7,9}'
+      :nationalNumberPattern: '[24-9]\d{7,9}'
       :possibleNumberPattern: \d{8,10}
     :fixedLine:
       :nationalNumberPattern: 2[24-7]\d{6}
@@ -1720,10 +1720,10 @@
       :exampleNumber: '40001234'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[24-7]|8[3-9]'
-    :format: $1$2
+    :leadingDigits: '[24-7]|8[3-9]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{4})
-    :leadingDigits: ! '[89]0'
+    :leadingDigits: '[89]0'
     :format: $1-$2-$3
 - :id: CU
   :countryCode: '53'
@@ -1732,7 +1732,7 @@
   :nationalPrefixFormattingRule: ($NP$FG)
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57]\d{5,7}'
+      :nationalNumberPattern: '[2-57]\d{5,7}'
       :possibleNumberPattern: \d{4,8}
     :fixedLine:
       :nationalNumberPattern: 2[1-4]\d{5,6}|3(?:1\d{6}|[23]\d{4,6})|4(?:[125]\d{5,6}|[36]\d{6}|[78]\d{4,6})|7\d{6,7}
@@ -1744,20 +1744,20 @@
   :formats:
   - :pattern: (\d)(\d{6,7})
     :leadingDigits: '7'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{4,6})
-    :leadingDigits: ! '[2-4]'
-    :format: $1$2
+    :leadingDigits: '[2-4]'
+    :format: $1 $2
   - :pattern: (\d)(\d{7})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: '5'
-    :format: $1$2
+    :format: $1 $2
 - :id: CV
   :countryCode: '238'
   :internationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[259]\d{6}'
+      :nationalNumberPattern: '[259]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 2(?:2[1-7]|3[0-8]|4[12]|5[1256]|6\d|7[1-3]|8[1-5])\d{4}
@@ -1767,14 +1767,14 @@
       :exampleNumber: '9911234'
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: CW
   :countryCode: '599'
   :internationalPrefix: '00'
   :mainCountryForCode: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[169]\d{6,7}'
+      :nationalNumberPattern: '[169]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: 9(?:[48]\d{2}|50\d|7(?:2[0-2]|[34]\d|6[35-7]|77))\d{4}
@@ -1791,11 +1791,11 @@
       :exampleNumber: '1011234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[13-7]'
-    :format: $1$2
+    :leadingDigits: '[13-7]'
+    :format: $1 $2
   - :pattern: (9)(\d{3})(\d{4})
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: CX
   :countryCode: '61'
   :preferredInternationalPrefix: '0011'
@@ -1803,7 +1803,7 @@
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1458]\d{5,9}'
+      :nationalNumberPattern: '[1458]\d{5,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: 89164\d{4}
@@ -1835,7 +1835,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[257-9]\d{7}'
+      :nationalNumberPattern: '[257-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2[2-6]\d{6}
@@ -1860,14 +1860,14 @@
       :exampleNumber: '77123456'
   :formats:
   - :pattern: (\d{2})(\d{6})
-    :format: $1$2
+    :format: $1 $2
 - :id: CZ
   :countryCode: '420'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{8}|9\d{8,11}'
+      :nationalNumberPattern: '[2-8]\d{8}|9\d{8,11}'
       :possibleNumberPattern: \d{9,12}
     :fixedLine:
       :nationalNumberPattern: 2\d{8}|(?:3[1257-9]|4[16-9]|5[13-9])\d{7}
@@ -1899,14 +1899,14 @@
       :exampleNumber: '93123456789'
   :formats:
   - :pattern: ([2-9]\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[2-8]|9[015-7]'
-    :format: $1$2$3
+    :leadingDigits: '[2-8]|9[015-7]'
+    :format: $1 $2 $3
   - :pattern: (96\d)(\d{3})(\d{3})(\d{3})
     :leadingDigits: '96'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (9\d)(\d{3})(\d{3})(\d{3})
     :leadingDigits: 9[36]
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: DE
   :countryCode: '49'
   :internationalPrefix: '00'
@@ -1915,10 +1915,10 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-35-9]\d{3,14}|4(?:[0-8]\d{4,12}|9(?:[0-37]\d|4(?:[1-35-8]|4\d?)|5\d{1,2}|6[1-8]\d?)\d{2,7})'
+      :nationalNumberPattern: '[1-35-9]\d{3,14}|4(?:[0-8]\d{4,12}|9(?:[0-37]\d|4(?:[1-35-8]|4\d?)|5\d{1,2}|6[1-8]\d?)\d{2,7})'
       :possibleNumberPattern: \d{2,15}
     :fixedLine:
-      :nationalNumberPattern: ! '[246]\d{5,13}|3(?:0\d{3,13}|2\d{9}|[3-9]\d{4,13})|5(?:0[2-8]|[1256]\d|[38][0-8]|4\d{0,2}|[79][0-7])\d{3,11}|7(?:0[2-8]|[1-9]\d)\d{3,10}|8(?:0[2-9]|[1-9]\d)\d{3,10}|9(?:0[6-9]\d{3,10}|1\d{4,12}|[2-9]\d{4,11})'
+      :nationalNumberPattern: '[246]\d{5,13}|3(?:0\d{3,13}|2\d{9}|[3-9]\d{4,13})|5(?:0[2-8]|[1256]\d|[38][0-8]|4\d{0,2}|[79][0-7])\d{3,11}|7(?:0[2-8]|[1-9]\d)\d{3,10}|8(?:0[2-9]|[1-9]\d)\d{3,10}|9(?:0[6-9]\d{3,10}|1\d{4,12}|[2-9]\d{4,11})'
       :exampleNumber: '30123456'
     :mobile:
       :nationalNumberPattern: 1(?:5[0-2579]\d{8}|6[023]\d{7,8}|7(?:[0-57-9]\d?|6\d)\d{7})
@@ -1955,52 +1955,52 @@
   :formats:
   - :pattern: (1\d{2})(\d{7,8})
     :leadingDigits: 1[67]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (1\d{3})(\d{7})
     :leadingDigits: '15'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{3,11})
     :leadingDigits: 3[02]|40|[68]9
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3,11})
     :leadingDigits: 2(?:\d1|0[2389]|1[24]|28|34)|3(?:[3-9][15]|40)|[4-8][1-9]1|9(?:06|[1-9]1)
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{4})(\d{2,11})
-    :leadingDigits: ! '[24-6]|[7-9](?:\d[1-9]|[1-9]\d)|3(?:3(?:0[1-467]|2[127-9]|3[124578]|[46][1246]|7[1257-9]|8[1256]|9[145])|4(?:2[135]|3[1357]|4[13578]|6[1246]|7[1356]|9[1346])|5(?:0[14]|2[1-3589]|3[1357]|4[1246]|6[1-4]|7[1346]|8[13568]|9[1246])|6(?:0[356]|2[1-489]|3[124-6]|4[1347]|6[13]|7[12579]|8[1-356]|9[135])|7(?:2[1-7]|3[1357]|4[145]|6[1-5]|7[1-4])|8(?:21|3[1468]|4[1347]|6[0135-9]|7[1467]|8[136])|9(?:0[12479]|2[1358]|3[1357]|4[134679]|6[1-9]|7[136]|8[147]|9[1468]))'
-    :format: $1$2
+    :leadingDigits: '[24-6]|[7-9](?:\d[1-9]|[1-9]\d)|3(?:3(?:0[1-467]|2[127-9]|3[124578]|[46][1246]|7[1257-9]|8[1256]|9[145])|4(?:2[135]|3[1357]|4[13578]|6[1246]|7[1356]|9[1346])|5(?:0[14]|2[1-3589]|3[1357]|4[1246]|6[1-4]|7[1346]|8[13568]|9[1246])|6(?:0[356]|2[1-489]|3[124-6]|4[1347]|6[13]|7[12579]|8[1-356]|9[135])|7(?:2[1-7]|3[1357]|4[145]|6[1-5]|7[1-4])|8(?:21|3[1468]|4[1347]|6[0135-9]|7[1467]|8[136])|9(?:0[12479]|2[1358]|3[1357]|4[134679]|6[1-9]|7[136]|8[147]|9[1468]))'
+    :format: $1 $2
   - :pattern: (3\d{4})(\d{1,10})
     :leadingDigits: '3'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (800)(\d{7,12})
     :leadingDigits: '800'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (177)(99)(\d{7,8})
     :leadingDigits: '17799'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d)(\d{4,10})
     :leadingDigits: 180|900[1359]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1\d{2})(\d{5,11})
     :leadingDigits: '181'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (18\d{3})(\d{6})
     :leadingDigits: '18500'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (18\d{2})(\d{7})
     :leadingDigits: 18[68]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (18\d)(\d{8})
     :leadingDigits: 18[2-579]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (700)(\d{4})(\d{4})
     :leadingDigits: '700'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: DJ
   :countryCode: '253'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[27]\d{7}'
+      :nationalNumberPattern: '[27]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:1[2-5]|7[45])\d{5}
@@ -2010,14 +2010,14 @@
       :exampleNumber: '77831001'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: DK
   :countryCode: '45'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{7}'
+      :nationalNumberPattern: '[2-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:[2-7]\d|8[126-9]|9[126-9])\d{6}
@@ -2033,7 +2033,7 @@
       :exampleNumber: '90123456'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: DM
   :countryCode: '1'
   :leadingDigits: '767'
@@ -2041,7 +2041,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[57-9]\d{9}'
+      :nationalNumberPattern: '[57-9]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 767(?:2(?:55|66)|4(?:2[01]|4[0-25-9])|50[0-4])\d{4}
@@ -2070,7 +2070,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[589]\d{9}'
+      :nationalNumberPattern: '[589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 8(?:[04]9[2-9]\d{6}|29(?:2(?:[0-59]\d|6[04-9]|7[0-27]|8[0237-9])|3(?:[0-35-9]\d|4[7-9])|[45]\d{2}|6(?:[0-27-9]\d|[3-5][1-9]|6[0135-8])|7(?:0[013-9]|[1-37]\d|4[1-35689]|5[1-4689]|6[1-57-9]|8[1-79]|9[1-8])|8(?:0[146-9]|1[0-48]|[248]\d|3[1-79]|5[01589]|6[013-68]|7[124-8]|9[0-8])|9(?:[0-24]\d|3[02-46-9]|5[0-79]|60|7[0169]|8[57-9]|9[02-9]))\d{4})
@@ -2124,14 +2124,14 @@
       :exampleNumber: '983123456'
   :formats:
   - :pattern: ([1-4]\d)(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[1-4]'
-    :format: $1$2$3$4
+    :leadingDigits: '[1-4]'
+    :format: $1 $2 $3 $4
   - :pattern: ([5-8]\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[5-8]'
-    :format: $1$2$3$4
+    :leadingDigits: '[5-8]'
+    :format: $1 $2 $3 $4
   - :pattern: (9\d)(\d{3})(\d{2})(\d{2})
     :leadingDigits: '9'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: EC
   :countryCode: '593'
   :internationalPrefix: '00'
@@ -2143,7 +2143,7 @@
       :nationalNumberPattern: 1\d{9,10}|[2-8]\d{7}|9\d{8}
       :possibleNumberPattern: \d{7,11}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-7][2-7]\d{6}'
+      :nationalNumberPattern: '[2-7][2-7]\d{6}'
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '22123456'
     :mobile:
@@ -2155,22 +2155,22 @@
       :possibleNumberPattern: \d{10,11}
       :exampleNumber: '18001234567'
     :voip:
-      :nationalNumberPattern: ! '[2-7]890\d{4}'
+      :nationalNumberPattern: '[2-7]890\d{4}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '28901234'
   :formats:
   - :pattern: (\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[247]|[356][2-8]'
-    :format: $1$2-$3
+    :leadingDigits: '[247]|[356][2-8]'
+    :format: $1 $2-$3
     :intlFormat: $1-$2-$3
   - :pattern: (\d{2})(\d{3})(\d{4})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1800)(\d{3})(\d{3,4})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: EE
   :countryCode: '372'
   :internationalPrefix: '00'
@@ -2209,17 +2209,17 @@
       :exampleNumber: '12123'
   :formats:
   - :pattern: ([3-79]\d{2})(\d{4})
-    :leadingDigits: ! '[369]|4[3-8]|5(?:[02]|1(?:[0-8]|95)|5[0-478]|6(?:4[0-4]|5[1-589]))|7[1-9]'
-    :format: $1$2
+    :leadingDigits: '[369]|4[3-8]|5(?:[02]|1(?:[0-8]|95)|5[0-478]|6(?:4[0-4]|5[1-589]))|7[1-9]'
+    :format: $1 $2
   - :pattern: (70)(\d{2})(\d{4})
     :leadingDigits: '70'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (8000)(\d{3})(\d{3})
     :leadingDigits: '8000'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([458]\d{3})(\d{3,4})
     :leadingDigits: 40|5|8(?:00[1-9]|[1-5])
-    :format: $1$2
+    :format: $1 $2
 - :id: EG
   :countryCode: '20'
   :internationalPrefix: '00'
@@ -2248,14 +2248,14 @@
       :exampleNumber: '9001234567'
   :formats:
   - :pattern: (\d)(\d{7,8})
-    :leadingDigits: ! '[23]'
-    :format: $1$2
+    :leadingDigits: '[23]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 1[012]|[89]00
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{6,7})
     :leadingDigits: 1(?:3|5[23])|[4-6]|[89][2-9]
-    :format: $1$2
+    :format: $1 $2
 - :id: EH
   :countryCode: '212'
   :leadingDigits: 528[89]
@@ -2264,7 +2264,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{8}'
+      :nationalNumberPattern: '[5689]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 528[89]\d{5}
@@ -2285,7 +2285,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[178]\d{6}'
+      :nationalNumberPattern: '[178]\d{6}'
       :possibleNumberPattern: \d{6,7}
     :fixedLine:
       :nationalNumberPattern: 1(?:1[12568]|20|40|55|6[146])\d{4}|8\d{6}
@@ -2296,14 +2296,14 @@
       :exampleNumber: '7123456'
   :formats:
   - :pattern: (\d)(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: ES
   :countryCode: '34'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5-9]\d{8}'
+      :nationalNumberPattern: '[5-9]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 8(?:[13]0|[28][0-8]|[47][1-9]|5[01346-9]|6[0457-9])\d{6}|9(?:[1238][0-8]\d{6}|4[1-9]\d{6}|5\d{7}|6(?:[0-8]\d{6}|9(?:0(?:[0-57-9]\d{4}|6(?:0[0-8]|1[1-9]|[2-9]\d)\d{2})|[1-9]\d{5}))|7(?:[124-9]\d{2}|3(?:[0-8]\d|9[1-9]))\d{4})
@@ -2312,7 +2312,7 @@
       :nationalNumberPattern: (?:6\d{6}|7[1-4]\d{5}|9(?:6906(?:09|10)|7390\d{2}))\d{2}
       :exampleNumber: '612345678'
     :tollFree:
-      :nationalNumberPattern: ! '[89]00\d{6}'
+      :nationalNumberPattern: '[89]00\d{6}'
       :exampleNumber: '800123456'
     :premiumRate:
       :nationalNumberPattern: 80[367]\d{6}
@@ -2328,8 +2328,8 @@
       :exampleNumber: '511234567'
   :formats:
   - :pattern: ([5-9]\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[568]|[79][0-8]'
-    :format: $1$2$3$4
+    :leadingDigits: '[568]|[79][0-8]'
+    :format: $1 $2 $3 $4
 - :id: ET
   :countryCode: '251'
   :internationalPrefix: '00'
@@ -2337,7 +2337,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-59]\d{8}'
+      :nationalNumberPattern: '[1-59]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:11(?:1(?:1[124]|2[2-57]|3[1-5]|5[5-8]|8[6-8])|2(?:13|3[6-8]|5[89]|7[05-9]|8[2-6])|3(?:2[01]|3[0-289]|4[1289]|7[1-4]|87)|4(?:1[69]|3[2-49]|4[0-3]|6[5-8])|5(?:1[57]|44|5[0-4])|6(?:18|2[69]|4[5-7]|5[1-5]|6[0-59]|8[015-8]))|2(?:2(?:11[1-9]|22[0-7]|33\d|44[1467]|66[1-68])|5(?:11[124-6]|33[2-8]|44[1467]|55[14]|66[1-3679]|77[124-79]|880))|3(?:3(?:11[0-46-8]|22[0-6]|33[0134689]|44[04]|55[0-6]|66[01467])|4(?:44[0-8]|55[0-69]|66[0-3]|77[1-5]))|4(?:6(?:22[0-24-7]|33[1-5]|44[13-69]|55[14-689]|660|88[1-4])|7(?:11[1-9]|22[1-9]|33[13-7]|44[13-6]|55[1-689]))|5(?:7(?:227|55[05]|(?:66|77)[14-8])|8(?:11[149]|22[013-79]|33[0-68]|44[013-8]|550|66[1-5]|77\d)))\d{4}
@@ -2348,7 +2348,7 @@
       :exampleNumber: '911234567'
   :formats:
   - :pattern: ([1-59]\d)(\d{3})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: FI
   :countryCode: '358'
   :internationalPrefix: 00|99[049]
@@ -2361,7 +2361,7 @@
       :nationalNumberPattern: 1\d{4,11}|[2-9]\d{4,10}
       :possibleNumberPattern: \d{5,12}
     :noInternationalDialling:
-      :nationalNumberPattern: ! '[13]00\d{3,7}|2(?:0(?:0\d{3,7}|2[023]\d{1,6}|9[89]\d{1,6}))|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
+      :nationalNumberPattern: '[13]00\d{3,7}|2(?:0(?:0\d{3,7}|2[023]\d{1,6}|9[89]\d{1,6}))|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
       :possibleNumberPattern: \d{5,10}
       :exampleNumber: '100123'
     :fixedLine:
@@ -2376,23 +2376,23 @@
       :possibleNumberPattern: \d{7,10}
       :exampleNumber: '8001234567'
     :premiumRate:
-      :nationalNumberPattern: ! '[67]00\d{5,6}'
+      :nationalNumberPattern: '[67]00\d{5,6}'
       :possibleNumberPattern: \d{8,9}
       :exampleNumber: '600123456'
     :uan:
-      :nationalNumberPattern: ! '[13]0\d{4,8}|2(?:0(?:[016-8]\d{3,7}|[2-59]\d{2,7})|9\d{4,8})|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
+      :nationalNumberPattern: '[13]0\d{4,8}|2(?:0(?:[016-8]\d{3,7}|[2-59]\d{2,7})|9\d{4,8})|60(?:[12]\d{5,6}|6\d{7})|7(?:1\d{7}|3\d{8}|5[03-9]\d{2,7})'
       :possibleNumberPattern: \d{5,10}
       :exampleNumber: '10112345'
   :formats:
   - :pattern: (\d{3})(\d{3,7})
     :leadingDigits: (?:[1-3]00|[6-8]0)
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{4,10})
     :leadingDigits: 2[09]|[14]|50|7[135]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d)(\d{4,11})
-    :leadingDigits: ! '[25689][1-8]|3'
-    :format: $1$2
+    :leadingDigits: '[25689][1-8]|3'
+    :format: $1 $2
 - :id: FJ
   :countryCode: '679'
   :internationalPrefix: 0(?:0|52)
@@ -2400,7 +2400,7 @@
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[36-9]\d{6}|0\d{10}'
+      :nationalNumberPattern: '[36-9]\d{6}|0\d{10}'
       :possibleNumberPattern: \d{7}(?:\d{4})?
     :fixedLine:
       :nationalNumberPattern: (?:3[0-5]|6[25-7]|8[58])\d{5}
@@ -2416,30 +2416,30 @@
       :exampleNumber: 08001234567
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[36-9]'
-    :format: $1$2
+    :leadingDigits: '[36-9]'
+    :format: $1 $2
   - :pattern: (\d{4})(\d{3})(\d{4})
     :leadingDigits: '0'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: FK
   :countryCode: '500'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-7]\d{4}'
+      :nationalNumberPattern: '[2-7]\d{4}'
       :possibleNumberPattern: \d{5}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-47]\d{4}'
+      :nationalNumberPattern: '[2-47]\d{4}'
       :exampleNumber: '31234'
     :mobile:
-      :nationalNumberPattern: ! '[56]\d{4}'
+      :nationalNumberPattern: '[56]\d{4}'
       :exampleNumber: '51234'
 - :id: FM
   :countryCode: '691'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[39]\d{6}'
+      :nationalNumberPattern: '[39]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 3[2357]0[1-9]\d{3}|9[2-6]\d{5}
@@ -2449,7 +2449,7 @@
       :exampleNumber: '3501234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: FO
   :countryCode: '298'
   :internationalPrefix: '00'
@@ -2457,7 +2457,7 @@
   :carrierCodeFormattingRule: $CC$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{5}'
+      :nationalNumberPattern: '[2-9]\d{5}'
       :possibleNumberPattern: \d{6}
     :fixedLine:
       :nationalNumberPattern: (?:20|[3-4]\d|8[19])\d{4}
@@ -2485,10 +2485,10 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{8}'
+      :nationalNumberPattern: '[1-9]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
-      :nationalNumberPattern: ! '[1-5]\d{8}'
+      :nationalNumberPattern: '[1-5]\d{8}'
       :exampleNumber: '123456789'
     :mobile:
       :nationalNumberPattern: 6\d{8}|7[5-9]\d{7}
@@ -2507,17 +2507,17 @@
       :exampleNumber: '912345678'
   :formats:
   - :pattern: ([1-79])(\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[1-79]'
-    :format: $1$2$3$4$5
+    :leadingDigits: '[1-79]'
+    :format: $1 $2 $3 $4 $5
   - :pattern: (1\d{2})(\d{3})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '11'
-    :format: $1$2
+    :format: $1 $2
     :intlFormat: NA
   - :nationalPrefixFormattingRule: $NP $FG
     :pattern: (8\d{2})(\d{2})(\d{2})(\d{2})
     :leadingDigits: '8'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: GA
   :countryCode: '241'
   :internationalPrefix: '00'
@@ -2534,7 +2534,7 @@
       :exampleNumber: '06031234'
   :formats:
   - :pattern: (0\d)(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: GB
   :countryCode: '44'
   :internationalPrefix: '00'
@@ -2589,34 +2589,34 @@
   :formats:
   - :pattern: (\d{2})(\d{4})(\d{4})
     :leadingDigits: 2|5[56]|7(?:0|6(?:[013-9]|2[0-35-9]))
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 1(?:1|\d1)|3|9[018]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{5})(\d{4,5})
     :leadingDigits: 1(?:3873|5(?:242|39[456])|697[347]|768[347]|9467)
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (1\d{3})(\d{5,6})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (7\d{3})(\d{6})
     :leadingDigits: 7(?:[1-5789]|624)
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (800)(\d{4})
     :leadingDigits: '8001111'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (845)(46)(4\d)
     :leadingDigits: '845464'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (8\d{2})(\d{3})(\d{4})
     :leadingDigits: 8(?:4[2-5]|7[0-3])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (80\d)(\d{3})(\d{4})
     :leadingDigits: '80'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([58]00)(\d{6})
-    :leadingDigits: ! '[58]00'
-    :format: $1$2
+    :leadingDigits: '[58]00'
+    :format: $1 $2
 - :id: GD
   :countryCode: '1'
   :leadingDigits: '473'
@@ -2624,7 +2624,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[4589]\d{9}'
+      :nationalNumberPattern: '[4589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 473(?:2(?:3[0-2]|69)|3(?:2[89]|86)|4(?:[06]8|3[5-9]|4[0-49]|5[5-79]|68|73|90)|63[68]|7(?:58|84)|938)\d{4}
@@ -2656,7 +2656,7 @@
       :possibleNumberPattern: \d{9}
       :exampleNumber: '706123456'
     :generalDesc:
-      :nationalNumberPattern: ! '[34578]\d{8}'
+      :nationalNumberPattern: '[34578]\d{8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:3(?:[256]\d|4[124-9]|7[0-4])|4(?:1\d|2[2-7]|3[1-79]|4[2-8]|7[239]|9[1-7]))\d{6}
@@ -2677,16 +2677,16 @@
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[348]'
-    :format: $1$2$3$4
+    :leadingDigits: '[348]'
+    :format: $1 $2 $3 $4
   - :pattern: (\d{3})(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '5'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: GF
   :countryCode: '594'
   :internationalPrefix: '00'
@@ -2694,7 +2694,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[56]\d{8}'
+      :nationalNumberPattern: '[56]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 594(?:10|2[012457-9]|3[0-57-9]|4[3-9]|5[7-9]|6[0-3]|9[014])\d{4}
@@ -2704,7 +2704,7 @@
       :exampleNumber: '694201234'
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: GG
   :countryCode: '44'
   :internationalPrefix: '00'
@@ -2713,7 +2713,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[135789]\d{6,9}'
+      :nationalNumberPattern: '[135789]\d{6,9}'
       :possibleNumberPattern: \d{6,10}
     :areaCodeOptional:
       :nationalNumberPattern: 1481[2-9]\d{5}
@@ -2762,7 +2762,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[235]\d{8}|8\d{7}'
+      :nationalNumberPattern: '[235]\d{8}|8\d{7}'
       :possibleNumberPattern: \d{7,9}
     :noInternationalDialling:
       :nationalNumberPattern: 800\d{5}
@@ -2782,17 +2782,17 @@
       :exampleNumber: '80012345'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[235]'
-    :format: $1$2$3
+    :leadingDigits: '[235]'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{5})
     :leadingDigits: '8'
-    :format: $1$2
+    :format: $1 $2
 - :id: GI
   :countryCode: '350'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2568]\d{7}'
+      :nationalNumberPattern: '[2568]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:00\d|16[0-7]|22[2457])\d{4}
@@ -2814,13 +2814,13 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-689]\d{5}'
+      :nationalNumberPattern: '[1-689]\d{5}'
       :possibleNumberPattern: \d{6}
     :fixedLine:
       :nationalNumberPattern: (?:19|3[1-6]|6[14689]|8[14-79]|9\d)\d{4}
       :exampleNumber: '321000'
     :mobile:
-      :nationalNumberPattern: ! '[245][2-9]\d{4}'
+      :nationalNumberPattern: '[245][2-9]\d{4}'
       :exampleNumber: '221234'
     :tollFree:
       :nationalNumberPattern: 80\d{4}
@@ -2830,13 +2830,13 @@
       :exampleNumber: '381234'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: GM
   :countryCode: '220'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{6}'
+      :nationalNumberPattern: '[2-9]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: (?:4(?:[23]\d{2}|4(?:1[024679]|[6-9]\d))|5(?:54[0-7]|6(?:[67]\d)|7(?:1[04]|2[035]|3[58]|48))|8\d{3})\d{3}
@@ -2846,13 +2846,13 @@
       :exampleNumber: '3012345'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: GN
   :countryCode: '224'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[367]\d{7,8}'
+      :nationalNumberPattern: '[367]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
       :nationalNumberPattern: 30(?:24|3[12]|4[1-35-7]|5[13]|6[189]|[78]1|9[1478])\d{4}
@@ -2869,10 +2869,10 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
     :leadingDigits: '3'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[67]'
-    :format: $1$2$3$4
+    :leadingDigits: '[67]'
+    :format: $1 $2 $3 $4
 - :id: GP
   :countryCode: '590'
   :internationalPrefix: '00'
@@ -2881,7 +2881,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[56]\d{8}'
+      :nationalNumberPattern: '[56]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 590(?:0[13468]|1[012]|2[0-68]|3[28]|4[0-8]|5[579]|6[0189]|70|8[0-689]|9\d)\d{4}
@@ -2891,13 +2891,13 @@
       :exampleNumber: '690301234'
   :formats:
   - :pattern: ([56]90)(\d{2})(\d{4})
-    :format: $1$2-$3
+    :format: $1 $2-$3
 - :id: GQ
   :countryCode: '240'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[23589]\d{8}'
+      :nationalNumberPattern: '[23589]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 3(?:3(?:3\d[7-9]|[0-24-9]\d[46])|5\d{2}[7-9])\d{4}
@@ -2913,18 +2913,18 @@
       :exampleNumber: '900123456'
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
-    :leadingDigits: ! '[235]'
-    :format: $1$2$3
+    :leadingDigits: '[235]'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{6})
-    :leadingDigits: ! '[89]'
-    :format: $1$2
+    :leadingDigits: '[89]'
+    :format: $1 $2
 - :id: GR
   :countryCode: '30'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[26-9]\d{9}'
+      :nationalNumberPattern: '[26-9]\d{9}'
       :possibleNumberPattern: \d{10}
     :fixedLine:
       :nationalNumberPattern: 2(?:1\d{2}|2(?:3[1-8]|4[1-7]|5[1-4]|6[1-8]|7[1-5]|[289][1-9])|3(?:1\d|2[1-57]|3[1-4]|[45][1-3]|7[1-7]|8[1-6]|9[1-79])|4(?:1\d|2[1-8]|3[1-4]|4[13-5]|6[1-578]|9[1-5])|5(?:1\d|[239][1-4]|4[124]|5[1-6])|6(?:1\d|3[124]|4[1-7]|5[13-9]|[269][1-6]|7[14]|8[1-5])|7(?:1\d|2[1-5]|3[1-6]|4[1-7]|5[1-57]|6[134]|9[15-7])|8(?:1\d|2[1-5]|[34][1-4]|9[1-7]))\d{6}
@@ -2947,26 +2947,26 @@
   :formats:
   - :pattern: ([27]\d)(\d{4})(\d{4})
     :leadingDigits: 21|7
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 2[2-9]1|[689]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (2\d{3})(\d{6})
     :leadingDigits: 2[2-9][02-9]
-    :format: $1$2
+    :format: $1 $2
 - :id: GT
   :countryCode: '502'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-7]\d{7}|1[89]\d{9}'
+      :nationalNumberPattern: '[2-7]\d{7}|1[89]\d{9}'
       :possibleNumberPattern: \d{8}(?:\d{3})?
     :fixedLine:
-      :nationalNumberPattern: ! '[267][2-9]\d{6}'
+      :nationalNumberPattern: '[267][2-9]\d{6}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '22456789'
     :mobile:
-      :nationalNumberPattern: ! '[345]\d{7}'
+      :nationalNumberPattern: '[345]\d{7}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '51234567'
     :tollFree:
@@ -2979,11 +2979,11 @@
       :exampleNumber: '19001112222'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[2-7]'
-    :format: $1$2
+    :leadingDigits: '[2-7]'
+    :format: $1 $2
   - :pattern: (\d{4})(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: GU
   :countryCode: '1'
   :leadingDigits: '671'
@@ -2991,7 +2991,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{9}'
+      :nationalNumberPattern: '[5689]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 671(?:3(?:00|3[39]|4[349]|55|6[26])|4(?:56|7[1-9]|8[236-9])|5(?:55|6[2-5]|88)|6(?:3[2-578]|4[24-9]|5[34]|78|8[5-9])|7(?:[079]7|2[0167]|3[45]|8[789])|8(?:[2-5789]8|6[48])|9(?:2[29]|6[79]|7[179]|8[789]|9[78]))\d{4}
@@ -3016,7 +3016,7 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3-79]\d{6}'
+      :nationalNumberPattern: '[3-79]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 3(?:2[0125]|3[1245]|4[12]|5[1-4]|70|9[1-467])\d{4}
@@ -3029,13 +3029,13 @@
       :exampleNumber: '4012345'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: GY
   :countryCode: '592'
   :internationalPrefix: '001'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-4679]\d{6}'
+      :nationalNumberPattern: '[2-4679]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:1[6-9]|2[0-35-9]|3[1-4]|5[3-9]|6\d|7[0-24-79])|3(?:2[25-9]|3\d)|4(?:4[0-24]|5[56])|77[1-57])\d{4}
@@ -3051,14 +3051,14 @@
       :exampleNumber: '9008123'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: HK
   :countryCode: '852'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[235-7]\d{7}|8\d{7,8}|9\d{4,10}'
+      :nationalNumberPattern: '[235-7]\d{7}|8\d{7,8}|9\d{4,10}'
       :possibleNumberPattern: \d{5,11}
     :fixedLine:
       :nationalNumberPattern: (?:[23]\d|5[78])\d{6}
@@ -3086,29 +3086,29 @@
       :exampleNumber: '81123456'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[235-7]|[89](?:0[1-9]|[1-9])'
-    :format: $1$2
+    :leadingDigits: '[235-7]|[89](?:0[1-9]|[1-9])'
+    :format: $1 $2
   - :pattern: (800)(\d{3})(\d{3})
     :leadingDigits: '800'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (900)(\d{2})(\d{3})(\d{3})
     :leadingDigits: '900'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (900)(\d{2,5})
     :leadingDigits: '900'
-    :format: $1$2
+    :format: $1 $2
 - :id: HN
   :countryCode: '504'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[237-9]\d{7}'
+      :nationalNumberPattern: '[237-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:2(?:0[019]|1[1-36]|[23]\d|4[056]|5[57]|7[01389]|8[0146-9]|9[012])|4(?:2[3-59]|3[13-689]|4[0-68]|5[1-35])|5(?:4[3-5]|5\d|6[56]|74)|6(?:4[0-378]|[56]\d|[78][0-8]|9[01])|7(?:6[46-9]|7[02-9]|8[34])|8(?:79|8[0-35789]|9[1-57-9]))\d{4}
       :exampleNumber: '22123456'
     :mobile:
-      :nationalNumberPattern: ! '[37-9]\d{7}'
+      :nationalNumberPattern: '[37-9]\d{7}'
       :exampleNumber: '91234567'
   :formats:
   - :pattern: (\d{4})(\d{4})
@@ -3121,7 +3121,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-7]\d{5,8}|[89]\d{6,11}'
+      :nationalNumberPattern: '[1-7]\d{5,8}|[89]\d{6,11}'
       :possibleNumberPattern: \d{6,12}
     :fixedLine:
       :nationalNumberPattern: 1\d{7}|(?:2[0-3]|3[1-5]|4[02-47-9]|5[1-3])\d{6}
@@ -3150,43 +3150,43 @@
   :formats:
   - :pattern: (1)(\d{4})(\d{3})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6[09])(\d{4})(\d{3})
     :leadingDigits: 6[09]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (62)(\d{3})(\d{3,4})
     :leadingDigits: '62'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([2-5]\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[2-5]'
-    :format: $1$2$3
+    :leadingDigits: '[2-5]'
+    :format: $1 $2 $3
   - :pattern: (9\d)(\d{3})(\d{3,4})
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (9\d)(\d{4})(\d{4})
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (9\d)(\d{3,4})(\d{3})(\d{3})
     :leadingDigits: '9'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{2})(\d{2,3})
     :leadingDigits: 6[145]|7
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3,4})(\d{3})
     :leadingDigits: 6[145]|7
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (80[01])(\d{2})(\d{2,3})
     :leadingDigits: '8'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (80[01])(\d{3,4})(\d{3})
     :leadingDigits: '8'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: HT
   :countryCode: '509'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-489]\d{7}'
+      :nationalNumberPattern: '[2-489]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:[24]\d|5[1-5]|94)\d{5}
@@ -3204,7 +3204,7 @@
       :exampleNumber: '98901234'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: HU
   :countryCode: '36'
   :internationalPrefix: '00'
@@ -3213,7 +3213,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{7,8}'
+      :nationalNumberPattern: '[1-9]\d{7,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:1\d|2(?:1\d|[2-9])|3[2-7]|4[24-9]|5[2-79]|6[23689]|7(?:1\d|[2-9])|8[2-57-9]|9[2-69])\d{6}
@@ -3237,10 +3237,10 @@
   :formats:
   - :pattern: (1)(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[2-9]'
-    :format: $1$2$3
+    :leadingDigits: '[2-9]'
+    :format: $1 $2 $3
 - :id: ID
   :countryCode: '62'
   :internationalPrefix: 0(?:0[1789]|10(?:00|1[67]))
@@ -3248,7 +3248,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{6,10}'
+      :nationalNumberPattern: '[1-9]\d{6,10}'
       :possibleNumberPattern: \d{5,11}
     :fixedLine:
       :nationalNumberPattern: 2(?:1(?:[0-8]\d{6,7}|9\d{6})|[24]\d{7,8})|(?:2(?:[35][1-4]|6[0-8]|7[1-6]|8\d|9[1-8])|3(?:1|2[1-578]|3[1-68]|4[1-3]|5[1-8]|6[1-3568]|7[0-46]|8\d)|4(?:0[1-589]|1[01347-9]|2[0-36-8]|3[0-24-68]|5[1-378]|6[1-5]|7[134]|8[1245])|5(?:1[1-35-9]|2[25-8]|3[1246-9]|4[1-3589]|5[1-46]|6[1-8])|6(?:19?|[25]\d|3[1-469]|4[1-6])|7(?:1[1-46-9]|2[14-9]|[36]\d|4[1-8]|5[1-9]|7[0-36-9])|9(?:0[12]|1[013-8]|2[0-479]|5[125-8]|6[23679]|7[159]|8[01346]))\d{5,8}
@@ -3270,23 +3270,23 @@
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d{2})(\d{7,8})
     :leadingDigits: 2[124]|[36]1
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d{3})(\d{5,7})
-    :leadingDigits: ! '[4579]|2[035-9]|[36][02-9]'
-    :format: $1$2
+    :leadingDigits: '[4579]|2[035-9]|[36][02-9]'
+    :format: $1 $2
   - :pattern: (8\d{2})(\d{3,4})(\d{3,4})
     :leadingDigits: 8[1-35-9]
     :format: $1-$2-$3
   - :pattern: (177)(\d{6,8})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (800)(\d{5,7})
     :leadingDigits: '800'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (809)(\d)(\d{3})(\d{3})
     :leadingDigits: '809'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: IE
   :countryCode: '353'
   :internationalPrefix: '00'
@@ -3295,7 +3295,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[124-9]\d{6,9}'
+      :nationalNumberPattern: '[124-9]\d{6,9}'
       :possibleNumberPattern: \d{5,10}
     :noInternationalDialling:
       :nationalNumberPattern: 18[59]0\d{6}
@@ -3340,34 +3340,34 @@
   :formats:
   - :pattern: (1)(\d{3,4})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{5})
     :leadingDigits: 2[24-9]|47|58|6[237-9]|9[35-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{5})
     :leadingDigits: 40[24]|50[45]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (48)(\d{4})(\d{4})
     :leadingDigits: '48'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (818)(\d{3})(\d{3})
     :leadingDigits: '81'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[24-69]|7[14]'
-    :format: $1$2$3
+    :leadingDigits: '[24-69]|7[14]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([78]\d)(\d{3,4})(\d{4})
     :leadingDigits: 76|8[35-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (700)(\d{3})(\d{3})
     :leadingDigits: '70'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (\d{4})(\d{3})(\d{3})
     :leadingDigits: 1(?:8[059]0|5)
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: IL
   :countryCode: '972'
   :internationalPrefix: 0(?:0|1[2-9])
@@ -3376,14 +3376,14 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[17]\d{6,9}|[2-589]\d{3}(?:\d{3,6})?|6\d{3}'
+      :nationalNumberPattern: '[17]\d{6,9}|[2-589]\d{3}(?:\d{3,6})?|6\d{3}'
       :possibleNumberPattern: \d{4,10}
     :noInternationalDialling:
       :nationalNumberPattern: 1700\d{6}|[2-689]\d{3}
       :possibleNumberPattern: \d{4,10}
       :exampleNumber: '1700123456'
     :fixedLine:
-      :nationalNumberPattern: ! '[2-489]\d{7}'
+      :nationalNumberPattern: '[2-489]\d{7}'
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '21234567'
     :mobile:
@@ -3407,17 +3407,17 @@
       :possibleNumberPattern: \d{9}
       :exampleNumber: '771234567'
     :uan:
-      :nationalNumberPattern: ! '[2-689]\d{3}|1599\d{6}'
+      :nationalNumberPattern: '[2-689]\d{3}|1599\d{6}'
       :possibleNumberPattern: \d{4}(?:\d{6})?
       :exampleNumber: '1599123456'
   :formats:
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([2-489])(\d{3})(\d{4})
-    :leadingDigits: ! '[2-489]'
+    :leadingDigits: '[2-489]'
     :format: $1-$2-$3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([57]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[57]'
+    :leadingDigits: '[57]'
     :format: $1-$2-$3
   - :pattern: (1)([7-9]\d{2})(\d{3})(\d{3})
     :leadingDigits: 1[7-9]
@@ -3435,8 +3435,8 @@
     :leadingDigits: '15'
     :format: $1-$2
   - :pattern: (\d{4})
-    :leadingDigits: ! '[2-689]'
-    :format: ! '*$1'
+    :leadingDigits: '[2-689]'
+    :format: '*$1'
 - :id: IM
   :countryCode: '44'
   :internationalPrefix: '00'
@@ -3445,7 +3445,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[135789]\d{6,9}'
+      :nationalNumberPattern: '[135789]\d{6,9}'
       :possibleNumberPattern: \d{6,10}
     :areaCodeOptional:
       :nationalNumberPattern: 1624[2-9]\d{5}
@@ -3520,38 +3520,38 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{6})
     :leadingDigits: 7(?:2(?:0[04-9]|5[09]|7[5-8]|9[389])|3(?:0[1-9]|[58]|7[3679]|9[689])|4(?:0[1-9]|1[15-9]|[29][89]|39|8[389])|5(?:0|[47]9|[25]0|6[6-9]|[89][7-9])|6(?:0[027]|12|20|3[19]|5[45]|6[5-9]|7[679]|9[1-46-9])|7(?:0[2-9]|[1-79]|8[1-9])|8(?:[0-7]|9[013-9]))|8(?:0(?:[01589]|6[67])|1(?:[02-589]|1[0135-9]|7[0-79])|2(?:[236-9]|5[1-9])|3(?:[0357-9]|4[1-9])|[45]|6[02457-9]|7[1-69]|8(?:[0-26-9]|44|5[2-9])|9(?:[035-9]|2[2-9]|4[0-8]))|9
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{4})(\d{4})
     :leadingDigits: 11|2[02]|33|4[04]|79|80[2-46]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 1(?:2[0-249]|3[0-25]|4[145]|[569][14]|7[1257]|8[1346]|[68][1-9])|2(?:1[257]|3[013]|4[01]|5[0137]|6[0158]|78|8[1568]|9[14])|3(?:26|4[1-3]|5[34]|6[01489]|7[02-46]|8[159])|4(?:1[36]|2[1-47]|3[15]|5[12]|6[126-9]|7[0-24-9]|8[013-57]|9[014-7])|5(?:[136][25]|22|4[28]|5[12]|[78]1|9[15])|6(?:12|[2345]1|57|6[13]|7[14]|80)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 7(?:12|2[14]|3[134]|4[47]|5(?:1|5[2-6])|[67]1|88)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 8(?:16|2[014]|3[126]|6[136]|7[078]|8[34]|91)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{4})(\d{3})(\d{3})
     :leadingDigits: 1(?:[2-579]|[68][1-9])|[2-8]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1600)(\d{2})(\d{4})
     :leadingDigits: '1600'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1800)(\d{4,5})
     :leadingDigits: '1800'
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: $FG
     :pattern: (18[06]0)(\d{2,4})(\d{4})
     :leadingDigits: 18[06]0
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (\d{4})(\d{3})(\d{4})(\d{2})
     :leadingDigits: 18(?:03|6[12])
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: IO
   :countryCode: '246'
   :internationalPrefix: '00'
@@ -3567,7 +3567,7 @@
       :exampleNumber: '3801234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: IQ
   :countryCode: '964'
   :internationalPrefix: '00'
@@ -3575,7 +3575,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-7]\d{7,9}'
+      :nationalNumberPattern: '[1-7]\d{7,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: 1\d{7}|(?:2[13-5]|3[02367]|4[023]|5[03]|6[026])\d{6,7}
@@ -3588,13 +3588,13 @@
   :formats:
   - :pattern: (1)(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([2-6]\d)(\d{3})(\d{3,4})
-    :leadingDigits: ! '[2-6]'
-    :format: $1$2$3
+    :leadingDigits: '[2-6]'
+    :format: $1 $2 $3
   - :pattern: (7\d{2})(\d{3})(\d{4})
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: IR
   :countryCode: '98'
   :internationalPrefix: '00'
@@ -3602,7 +3602,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[14-8]\d{6,9}|[23]\d{4,9}|9(?:[1-4]\d{8}|9\d{2,8})'
+      :nationalNumberPattern: '[14-8]\d{6,9}|[23]\d{4,9}|9(?:[1-4]\d{8}|9\d{2,8})'
       :possibleNumberPattern: \d{4,10}
     :fixedLine:
       :nationalNumberPattern: 1(?:[13-589][12]|[27][1-4])\d{7}|2(?:1\d{3,8}|3[12]\d{7}|4(?:1\d{4,7}|2\d{7})|5(?:1\d{3,7}|[2356]\d{7})|6\d{8}|7[34]\d{7}|[89][12]\d{7})|3(?:1(?:1\d{4,7}|2\d{7})|2[1-4]\d{7}|3(?:[125]\d{7}|4\d{6,7})|4(?:1\d{6,7}[24-9]\d{7})|5(?:1\d{4,7}|[23]\d{7})|[6-9][12]\d{7})|4(?:[135-9][12]\d{7}|2[1-467]\d{7}|4(?:1\d{4,7}|[2-4]\d{7}))|5(?:1(?:1\d{4,7}|2\d{7})|2[89]\d{7}|3[1-5]\d{7}|4(?:1\d{4,7}|[2-8]\d{7})|[5-7][12]\d{7}|8[1245]\d{7})|6(?:1(?:1\d{6,7}|2\d{7})|[347-9][12]\d{7}|5(?:1\d{7}|2\d{6,7})|6[1-6]\d{7})|7(?:[13589][12]|2[1289]|4[1-4]|6[1-6]|7[1-3])\d{7}|8(?:[145][12]|3[124578]|6[1256]|7[1245])\d{7}
@@ -3627,29 +3627,29 @@
   - :pattern: (2[15])(\d{3,5})
     :comment: ''
     :leadingDigits: 2(?:1|5[0-47-9])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (2[15])(\d{3})(\d{3,4})
     :leadingDigits: 2(?:1|5[0-47-9])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (2\d)(\d{4})(\d{4})
     :leadingDigits: 2(?:[16]|5[0-47-9])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[13-9]|2[02-57-9]'
-    :format: $1$2$3
+    :leadingDigits: '[13-9]|2[02-57-9]'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{2,3})
-    :leadingDigits: ! '[13-9]|2[02-57-9]'
-    :format: $1$2$3
+    :leadingDigits: '[13-9]|2[02-57-9]'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})
-    :leadingDigits: ! '[13-9]|2[02-57-9]'
-    :format: $1$2
+    :leadingDigits: '[13-9]|2[02-57-9]'
+    :format: $1 $2
 - :id: IS
   :countryCode: '354'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[4-9]\d{6}|38\d{7}'
+      :nationalNumberPattern: '[4-9]\d{6}|38\d{7}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:4(?:[14][0-245]|2[0-7]|[37][0-8]|5[0-3568]|6\d|8[0-36-8])|5(?:05|[156]\d|2[02578]|3[013-7]|4[03-7]|7[0-2578]|8[0-35-9]|9[013-689])|87[23])\d{4}
@@ -3675,11 +3675,11 @@
       :exampleNumber: '388123456'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[4-9]'
-    :format: $1$2
+    :leadingDigits: '[4-9]'
+    :format: $1 $2
   - :pattern: (3\d{2})(\d{3})(\d{3})
     :leadingDigits: '3'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: IT
   :countryCode: '39'
   :internationalPrefix: '00'
@@ -3687,7 +3687,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[01589]\d{5,10}|3(?:[12457-9]\d{8}|[36]\d{7,9})'
+      :nationalNumberPattern: '[01589]\d{5,10}|3(?:[12457-9]\d{8}|[36]\d{7,9})'
       :possibleNumberPattern: \d{6,11}
     :noInternationalDialling:
       :nationalNumberPattern: 848\d{6}
@@ -3724,34 +3724,34 @@
   :formats:
   - :pattern: (\d{2})(\d{3,4})(\d{4})
     :leadingDigits: 0[26]|55
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (0[26])(\d{4})(\d{5})
     :leadingDigits: 0[26]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (0[26])(\d{4,6})
     :leadingDigits: 0[26]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (0\d{2})(\d{3,4})(\d{4})
     :leadingDigits: 0[13-57-9][0159]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3,6})
     :leadingDigits: 0[13-57-9][0159]|8(?:03|4[17]|9(?:2|[45][0-4]))
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (0\d{3})(\d{3})(\d{4})
     :leadingDigits: 0[13-57-9][2-46-8]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (0\d{3})(\d{2,6})
     :leadingDigits: 0[13-57-9][2-46-8]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[13]|8(?:00|4[08]|9(?:5[5-9]|9))'
-    :format: $1$2$3
+    :leadingDigits: '[13]|8(?:00|4[08]|9(?:5[5-9]|9))'
+    :format: $1 $2 $3
   - :pattern: (\d{4})(\d{4})
     :leadingDigits: 894[5-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{4})(\d{4})
     :leadingDigits: '3'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: JE
   :countryCode: '44'
   :internationalPrefix: '00'
@@ -3760,7 +3760,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[135789]\d{6,9}'
+      :nationalNumberPattern: '[135789]\d{6,9}'
       :possibleNumberPattern: \d{6,10}
     :areaCodeOptional:
       :nationalNumberPattern: 1534[2-9]\d{5}
@@ -3808,7 +3808,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[589]\d{9}'
+      :nationalNumberPattern: '[589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 876(?:5(?:0[12]|1[0-468]|2[35]|63)|6(?:0[1-3579]|1[027-9]|[23]\d|40|5[06]|6[2-589]|7[05]|8[04]|9[4-9])|7(?:0[2-689]|[1-6]\d|8[056]|9[45])|9(?:0[1-8]|1[02378]|[2-8]\d|9[2-468]))\d{4}
@@ -3837,7 +3837,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[235-9]\d{7,8}'
+      :nationalNumberPattern: '[235-9]\d{7,8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:6(?:2[0-35-9]|3[0-57-8]|4[24-7]|5[0-24-8]|[6-9][02])|7(?:0[1-79]|10|2[014-7]|3[0-689]|4[019]|5[0-3578]))|32(?:0[1-69]|1[1-35-7]|2[024-7]|3\d|[457][02]|60)|53(?:[013][02]|2[0-59]|49|5[0-35-9]|6[15]|7[45]|8[1-6]|9[0-36-9])|6(?:2[50]0|300|4(?:0[0125]|1[2-7]|2[0569]|[38][07-9]|4[025689]|6[0-589]|7\d|9[0-2])|5(?:[01][056]|2[034]|3[0-57-9]|4[17-8]|5[0-69]|6[0-35-9]|7[1-379]|8[0-68]|9[02-39]))|87(?:[02]0|7[08]|9[09]))\d{4}
@@ -3874,14 +3874,14 @@
   :formats:
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[2356]|87'
-    :format: $1$2$3
+    :leadingDigits: '[2356]|87'
+    :format: $1 $2 $3
   - :pattern: (7)(\d{4})(\d{4})
     :leadingDigits: 7[457-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{5,6})
     :leadingDigits: 70|8[0158]|9
-    :format: $1$2
+    :format: $1 $2
 - :id: JP
   :countryCode: '81'
   :internationalPrefix: '010'
@@ -3891,7 +3891,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{8,9}|0(?:[36]\d{7,14}|7\d{5,7}|8\d{7})'
+      :nationalNumberPattern: '[1-9]\d{8,9}|0(?:[36]\d{7,14}|7\d{5,7}|8\d{7})'
       :possibleNumberPattern: \d{7,16}
     :noInternationalDialling:
       :nationalNumberPattern: 0(?:37\d{6,13}|66\d{6,13}|777(?:[01]\d{2}|5\d{3}|8\d{4})|882[1245]\d{4})
@@ -3958,7 +3958,7 @@
     :leadingDigits: 0(?:37|66)
     :format: $1-$2-$3
   - :pattern: (\d{2})(\d{4})(\d{4})
-    :leadingDigits: ! '[2579]0|80[1-9]'
+    :leadingDigits: '[2579]0|80[1-9]'
     :format: $1-$2-$3
   - :pattern: (\d{4})(\d)(\d{4})
     :leadingDigits: 1(?:267|3(?:7[247]|9[278])|4(?:5[67]|66)|5(?:47|58|64|8[67])|6(?:3[245]|48|5[4-68]))|5(?:769|979[2-69])|499[2468]|7468|8(?:3(?:8[78]|96[2457-9])|636[2-57-9]|477|51[24])|9(?:496|802|9(?:1[23]|69))
@@ -3976,7 +3976,7 @@
     :leadingDigits: 3|4(?:2[09]|7[01])|6[1-9]
     :format: $1-$2-$3
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[2479][1-9]'
+    :leadingDigits: '[2479][1-9]'
     :format: $1-$2-$3
 - :id: KE
   :countryCode: '254'
@@ -4006,14 +4006,14 @@
       :exampleNumber: '900223456'
   :formats:
   - :pattern: (\d{2})(\d{4,7})
-    :leadingDigits: ! '[24-6]'
-    :format: $1$2
+    :leadingDigits: '[24-6]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{6,7})
     :leadingDigits: '7'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[89]'
-    :format: $1$2$3
+    :leadingDigits: '[89]'
+    :format: $1 $2 $3
 - :id: KG
   :countryCode: '996'
   :internationalPrefix: '00'
@@ -4021,7 +4021,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[35-8]\d{8,9}'
+      :nationalNumberPattern: '[35-8]\d{8,9}'
       :possibleNumberPattern: \d{5,10}
     :fixedLine:
       :nationalNumberPattern: (?:3(?:1(?:2\d|3[1-9]|47|5[02]|6[1-8])|2(?:22|3[0-479]|6[0-7])|4(?:22|5[6-9]|6[0-4])|5(?:22|3[4-7]|59|6[0-5])|6(?:22|5[35-7]|6[0-3])|7(?:22|3[468]|4[1-9]|59|6\d|7[5-7])|9(?:22|4[1-8]|6[0-8]))|6(?:09|12|2[2-4])\d)\d{5}
@@ -4037,20 +4037,20 @@
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
     :leadingDigits: 31[25]|[5-7]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{4})(\d{5})
     :leadingDigits: 3(?:1[36]|[2-9])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d)(\d{3})
     :leadingDigits: '8'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: KH
   :countryCode: '855'
   :internationalPrefix: 00[14-9]
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{7,9}'
+      :nationalNumberPattern: '[1-9]\d{7,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: (?:2[3-6]|3[2-6]|4[2-4]|[5-7][2-5])(?:[237-9]|4[56]|5\d|6\d?)\d{5}|238\d{6}
@@ -4072,17 +4072,17 @@
   - :pattern: (\d{2})(\d{3})(\d{3,4})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: 1\d[1-9]|[2-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1[89]00)(\d{3})(\d{3})
     :leadingDigits: 1[89]0
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: KI
   :countryCode: '686'
   :internationalPrefix: '00'
   :nationalPrefixForParsing: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-689]\d{4}'
+      :nationalNumberPattern: '[2-689]\d{4}'
       :possibleNumberPattern: \d{5}
     :fixedLine:
       :nationalNumberPattern: (?:[234]\d|50|8[1-5])\d{3}
@@ -4095,7 +4095,7 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[379]\d{6}'
+      :nationalNumberPattern: '[379]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 7(?:6[0-37-9]|7[0-57-9])\d{4}
@@ -4108,7 +4108,7 @@
       :exampleNumber: '9001234'
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: KN
   :countryCode: '1'
   :leadingDigits: '869'
@@ -4116,7 +4116,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[589]\d{9}'
+      :nationalNumberPattern: '[589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 869(?:2(?:29|36)|302|4(?:6[5-9]|70))\d{4}
@@ -4161,13 +4161,13 @@
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d)(\d{3})(\d{4})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3})
     :leadingDigits: '8'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: KR
   :countryCode: '82'
   :internationalPrefix: 00(?:[124-68]|[37]\d{2})
@@ -4178,7 +4178,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-7]\d{3,9}|8\d{8}'
+      :nationalNumberPattern: '[1-7]\d{3,9}|8\d{8}'
       :possibleNumberPattern: \d{4,10}
     :fixedLine:
       :nationalNumberPattern: (?:2|3[1-3]|[46][1-4]|5[1-5])(?:1\d{2,3}|[1-9]\d{6,7})
@@ -4238,7 +4238,7 @@
     :leadingDigits: 21[0-46-9]
     :format: $1-$2
   - :pattern: (\d{2})(\d{3,4})
-    :leadingDigits: ! '[3-6][1-9]1(?:[0-46-9])'
+    :leadingDigits: '[3-6][1-9]1(?:[0-46-9])'
     :format: $1-$2
   - :pattern: (\d{4})(\d{4})
     :nationalPrefixFormattingRule: $FG
@@ -4250,7 +4250,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[12569]\d{6,7}'
+      :nationalNumberPattern: '[12569]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:18\d|2(?:[23]\d{2}|4(?:[1-35-9]\d|44)|5(?:0[034]|[2-46]\d|5[1-3]|7[1-7])))\d{4}
@@ -4262,11 +4262,11 @@
       :exampleNumber: '50012345'
   :formats:
   - :pattern: (\d{4})(\d{3,4})
-    :leadingDigits: ! '[1269]'
-    :format: $1$2
+    :leadingDigits: '[1269]'
+    :format: $1 $2
   - :pattern: (5[015]\d)(\d{5})
     :leadingDigits: '5'
-    :format: $1$2
+    :format: $1 $2
 - :id: KY
   :countryCode: '1'
   :leadingDigits: '345'
@@ -4274,7 +4274,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3589]\d{9}'
+      :nationalNumberPattern: '[3589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 345(?:2(?:22|44)|444|6(?:23|38|40)|7(?:4[35-79]|6[6-9]|77)|8(?:00|1[45]|25|[48]8)|9(?:14|4[035-9]))\d{4}
@@ -4334,7 +4334,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{7,9}'
+      :nationalNumberPattern: '[2-8]\d{7,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: (?:2[13]|[35-7][14]|41|8[1468])\d{6}
@@ -4347,17 +4347,17 @@
   :formats:
   - :pattern: (20)(\d{2})(\d{3})(\d{3})
     :leadingDigits: '20'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: ([2-8]\d)(\d{3})(\d{3})
     :leadingDigits: 2[13]|[3-8]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: LB
   :countryCode: '961'
   :internationalPrefix: '00'
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[13-9]\d{6,7}'
+      :nationalNumberPattern: '[13-9]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:[14-6]\d{2}|7(?:[2-579]\d|62|8[0-7])|[89][2-9]\d)\d{4}
@@ -4378,11 +4378,11 @@
   :formats:
   - :pattern: (\d)(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[13-6]|7(?:[2-579]|62|8[0-7])|[89][2-9]'
-    :format: $1$2$3
+    :leadingDigits: '[13-6]|7(?:[2-579]|62|8[0-7])|[89][2-9]'
+    :format: $1 $2 $3
   - :pattern: ([7-9]\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[89][01]|7(?:[01]|6[013-9]|8[89]|91)'
-    :format: $1$2$3
+    :leadingDigits: '[89][01]|7(?:[01]|6[013-9]|8[89]|91)'
+    :format: $1 $2 $3
 - :id: LC
   :countryCode: '1'
   :leadingDigits: '758'
@@ -4390,7 +4390,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5789]\d{9}'
+      :nationalNumberPattern: '[5789]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 758(?:234|4(?:30|5[0-9]|6[2-9]|8[0-2])|572|638|758)\d{4}
@@ -4448,24 +4448,24 @@
       :exampleNumber: '7011234'
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[23]|7[3-57-9]|87'
-    :format: $1$2$3
+    :leadingDigits: '[23]|7[3-57-9]|87'
+    :format: $1 $2 $3
   - :pattern: (6\d)(\d{3})(\d{3})
     :leadingDigits: '6'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6[567]\d)(\d{3})(\d{3})
     :leadingDigits: 6[567]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (69)(7\d{2})(\d{4})
     :leadingDigits: '697'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([7-9]0\d)(\d{2})(\d{2})
-    :leadingDigits: ! '[7-9]0'
-    :format: $1$2$3
+    :leadingDigits: '[7-9]0'
+    :format: $1 $2 $3
   - :pattern: ([89]0\d)(\d{2})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[89]0'
-    :format: $1$2$3$4
+    :leadingDigits: '[89]0'
+    :format: $1 $2 $3 $4
 - :id: LK
   :countryCode: '94'
   :internationalPrefix: '00'
@@ -4473,7 +4473,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{8}'
+      :nationalNumberPattern: '[1-9]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:[189]1|2[13-7]|3[1-8]|4[157]|5[12457]|6[35-7])[2-57]\d{6}
@@ -4484,11 +4484,11 @@
       :exampleNumber: '712345678'
   :formats:
   - :pattern: (\d{2})(\d{1})(\d{6})
-    :leadingDigits: ! '[1-689]'
-    :format: $1$2$3
+    :leadingDigits: '[1-689]'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{4})
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: LR
   :countryCode: '231'
   :internationalPrefix: '00'
@@ -4515,47 +4515,47 @@
       :exampleNumber: '332001234'
   :formats:
   - :pattern: ([279]\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[279]'
-    :format: $1$2$3
+    :leadingDigits: '[279]'
+    :format: $1 $2 $3
   - :pattern: (7\d{2})(\d{3})(\d{3})
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([4-6])(\d{3})(\d{3})
-    :leadingDigits: ! '[4-6]'
-    :format: $1$2$3
+    :leadingDigits: '[4-6]'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[38]'
-    :format: $1$2$3
+    :leadingDigits: '[38]'
+    :format: $1 $2 $3
 - :id: LS
   :countryCode: '266'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2568]\d{7}'
+      :nationalNumberPattern: '[2568]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2\d{7}
       :exampleNumber: '22123456'
     :mobile:
-      :nationalNumberPattern: ! '[56]\d{7}'
+      :nationalNumberPattern: '[56]\d{7}'
       :exampleNumber: '50123456'
     :tollFree:
       :nationalNumberPattern: 800[256]\d{4}
       :exampleNumber: '80021234'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: LT
   :countryCode: '370'
   :internationalPrefix: '00'
   :nationalPrefix: '8'
-  :nationalPrefixForParsing: ! '[08]'
+  :nationalPrefixForParsing: '[08]'
   :nationalPrefixFormattingRule: ($NP-$FG)
   :nationalPrefixOptionalWhenFormatting: 'true'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3-9]\d{7}'
+      :nationalNumberPattern: '[3-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:3[1478]|4[124-6]|52)\d{6}
@@ -4581,17 +4581,17 @@
   :formats:
   - :pattern: ([34]\d)(\d{6})
     :leadingDigits: 37|4(?:1|5[45]|6[2-4])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([3-6]\d{2})(\d{5})
     :leadingDigits: 3[148]|4(?:[24]|6[09])|528|6
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([7-9]\d{2})(\d{2})(\d{3})
     :nationalPrefixFormattingRule: $NP $FG
-    :leadingDigits: ! '[7-9]'
-    :format: $1$2$3
+    :leadingDigits: '[7-9]'
+    :format: $1 $2 $3
   - :pattern: (5)(2\d{2})(\d{4})
     :leadingDigits: 52[0-79]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: LU
   :countryCode: '352'
   :internationalPrefix: '00'
@@ -4600,7 +4600,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24-9]\d{3,10}|3(?:[0-46-9]\d{2,9}|5[013-9]\d{1,8})'
+      :nationalNumberPattern: '[24-9]\d{3,10}|3(?:[0-46-9]\d{2,9}|5[013-9]\d{1,8})'
       :possibleNumberPattern: \d{4,11}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:2\d{1,2}|3[2-9]|[67]\d|4[1-8]\d?|5[1-5]\d?|9[0-24-9]\d?)|3(?:[059][05-9]|[13]\d|[26][015-9]|4[0-26-9]|7[0-389]|8[08])\d?|4\d{2,3}|5(?:[01458]\d|[27][0-69]|3[0-3]|[69][0-7])\d?|7(?:1[019]|2[05-9]|3[05]|[45][07-9]|[679][089]|8[06-9])\d?|8(?:0[2-9]|1[0-36-9]|3[3-9]|[469]9|[58][7-9]|7[89])\d?|9(?:0[89]|2[0-49]|37|49|5[0-27-9]|7[7-9]|9[0-478])\d?)\d{1,7}
@@ -4631,39 +4631,39 @@
       :exampleNumber: '20201234'
   :formats:
   - :pattern: (\d{2})(\d{3})
-    :leadingDigits: ! '[2-5]|7[1-9]|[89](?:[1-9]|0[2-9])'
-    :format: $1$2
+    :leadingDigits: '[2-5]|7[1-9]|[89](?:[1-9]|0[2-9])'
+    :format: $1 $2
   - :pattern: (\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[2-5]|7[1-9]|[89](?:[1-9]|0[2-9])'
-    :format: $1$2$3
+    :leadingDigits: '[2-5]|7[1-9]|[89](?:[1-9]|0[2-9])'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{3})
     :leadingDigits: '20'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{1,2})
     :leadingDigits: 2(?:[0367]|4[3-8])
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{3})
     :leadingDigits: '20'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})(\d{1,2})
     :leadingDigits: 2(?:[0367]|4[3-8])
-    :format: $1$2$3$4$5
+    :format: $1 $2 $3 $4 $5
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{1,4})
     :leadingDigits: 2(?:[12589]|4[12])|[3-5]|7[1-9]|[89](?:[1-9]|0[2-9])
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{3})(\d{2})(\d{3})
-    :leadingDigits: ! '[89]0[01]|70'
-    :format: $1$2$3
+    :leadingDigits: '[89]0[01]|70'
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{3})
     :leadingDigits: '6'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: LV
   :countryCode: '371'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2689]\d{7}'
+      :nationalNumberPattern: '[2689]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 6[3-8]\d{6}
@@ -4682,7 +4682,7 @@
       :exampleNumber: '81123456'
   :formats:
   - :pattern: ([2689]\d)(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: LY
   :countryCode: '218'
   :internationalPrefix: '00'
@@ -4690,7 +4690,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[25679]\d{8}'
+      :nationalNumberPattern: '[25679]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:2[1345]|5[1347]|6[123479]|71)\d{7}
@@ -4711,7 +4711,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{8}'
+      :nationalNumberPattern: '[5689]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 5(?:2(?:(?:[015-7]\d|2[2-9]|3[2-57]|4[2-8]|8[235-7])\d|9(?:0\d|[89]0))|3(?:(?:[0-4]\d|[57][2-9]|6[235-8]|9[3-9])\d|8(?:0\d|[89]0)))\d{4}
@@ -4745,7 +4745,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[4689]\d{7,8}'
+      :nationalNumberPattern: '[4689]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :noInternationalDialling:
       :nationalNumberPattern: 8\d{7}
@@ -4764,14 +4764,14 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $FG
-    :leadingDigits: ! '[89]'
-    :format: $1$2$3$4
+    :leadingDigits: '[89]'
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{3})(\d{3})
     :leadingDigits: '4'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6)(\d{2})(\d{2})(\d{2})(\d{2})
     :leadingDigits: '6'
-    :format: $1$2$3$4$5
+    :format: $1 $2 $3 $4 $5
 - :id: MD
   :countryCode: '373'
   :internationalPrefix: '00'
@@ -4780,7 +4780,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[235-9]\d{7}'
+      :nationalNumberPattern: '[235-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:1[0569]|2\d|3[015-7]|4[1-46-9]|5[0-24689]|6[2-589]|7[1-37]|9[1347-9])|5(?:33|5[257]))\d{5}
@@ -4806,13 +4806,13 @@
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{3})
     :leadingDigits: 22|3
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([25-7]\d{2})(\d{2})(\d{3})
     :leadingDigits: 2[13-79]|[5-7]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([89]\d{2})(\d{5})
-    :leadingDigits: ! '[89]'
-    :format: $1$2
+    :leadingDigits: '[89]'
+    :format: $1 $2
 - :id: ME
   :countryCode: '382'
   :internationalPrefix: '00'
@@ -4820,7 +4820,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{7,8}'
+      :nationalNumberPattern: '[2-9]\d{7,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:20[2-8]|3(?:0[2-7]|1[35-7]|2[3567]|3[4-7])|4(?:0[237]|1[27])|5(?:0[47]|1[27]|2[378]))\d{5}
@@ -4848,18 +4848,18 @@
       :exampleNumber: '77273012'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[2-57-9]|6(?:[389]|7(?:[0-8]|9[3-9]))'
-    :format: $1$2$3
+    :leadingDigits: '[2-57-9]|6(?:[389]|7(?:[0-8]|9[3-9]))'
+    :format: $1 $2 $3
   - :pattern: (67)(9)(\d{3})(\d{3})
     :leadingDigits: 679[0-2]
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: MF
   :countryCode: '590'
   :internationalPrefix: '00'
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[56]\d{8}'
+      :nationalNumberPattern: '[56]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 590(?:[02][79]|13|5[0-268]|[78]7)\d{4}
@@ -4874,7 +4874,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[23]\d{8}'
+      :nationalNumberPattern: '[23]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: 20(?:2\d{2}|4[47]\d|5[3467]\d|6[279]\d|7(?:2[29]|[35]\d)|8[268]\d|9[245]\d)\d{4}
@@ -4889,14 +4889,14 @@
       :exampleNumber: '221234567'
   :formats:
   - :pattern: ([23]\d)(\d{2})(\d{3})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: MH
   :countryCode: '692'
   :internationalPrefix: '011'
   :nationalPrefix: '1'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-6]\d{6}'
+      :nationalNumberPattern: '[2-6]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: (?:247|528|625)\d{4}
@@ -4918,7 +4918,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-578]\d{7}'
+      :nationalNumberPattern: '[2-578]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:[23]\d|5[124578]|6[01])|3(?:1[3-6]|[23][2-6]|4[2356])|4(?:[23][2-6]|4[3-6]|5[256]|6[25-8]|7[24-6]|8[4-6]))\d{5}
@@ -4939,33 +4939,33 @@
   :formats:
   - :pattern: (2)(\d{3})(\d{4})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([347]\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[347]'
-    :format: $1$2$3
+    :leadingDigits: '[347]'
+    :format: $1 $2 $3
   - :pattern: ([58]\d{2})(\d)(\d{2})(\d{2})
-    :leadingDigits: ! '[58]'
-    :format: $1$2$3$4
+    :leadingDigits: '[58]'
+    :format: $1 $2 $3 $4
 - :id: ML
   :countryCode: '223'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[246-9]\d{7}'
+      :nationalNumberPattern: '[246-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:0(?:2[0-589]|7\d)|1(?:2[5-7]|[3-689]\d|7[2-4689]))|44[239]\d)\d{4}
       :exampleNumber: '20212345'
     :mobile:
-      :nationalNumberPattern: ! '[67]\d{7}|9[0-25-9]\d{6}'
+      :nationalNumberPattern: '[67]\d{7}|9[0-25-9]\d{6}'
       :exampleNumber: '65012345'
     :tollFree:
       :nationalNumberPattern: 800\d{5}
       :exampleNumber: '80012345'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[246-9]'
-    :format: $1$2$3$4
+    :leadingDigits: '[246-9]'
+    :format: $1 $2 $3 $4
   - :pattern: (\d{4})
     :leadingDigits: 67|74
     :intlFormat: NA
@@ -4977,7 +4977,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[14578]\d{5,7}|[26]\d{5,8}|9(?:[258]|3\d|4\d{1,2}|[679]\d?)\d{6}'
+      :nationalNumberPattern: '[14578]\d{5,7}|[26]\d{5,8}|9(?:[258]|3\d|4\d{1,2}|[679]\d?)\d{6}'
       :possibleNumberPattern: \d{5,10}
     :fixedLine:
       :nationalNumberPattern: 1(?:2\d{1,2}|[3-5]\d|6\d?|[89][0-6]\d)\d{4}|2(?:[236-9]\d{4}|4(?:0\d{5}|\d{4})|5(?:1\d{3,6}|[02-9]\d{3,5}))|4(?:2[245-8]|[346][2-6]|5[3-5])\d{4}|5(?:2(?:20?|[3-8])|3[2-68]|4(?:21?|[4-8])|5[23]|6[2-4]|7[2-8]|8[24-7]|9[2-7])\d{4}|6(?:0[23]|1[2356]|[24][2-6]|3[24-6]|5[2-4]|6[2-8]|7(?:[2367]|4\d|5\d?|8[145]\d)|8[245]|9[24])\d{4}|7(?:[04][24-8]|[15][2-7]|22|3[2-4])\d{4}|8(?:1(?:2\d?|[3-689])|2[2-8]|3[24]|4[24-7]|5[245]|6[23])\d{4}
@@ -4994,25 +4994,25 @@
   :formats:
   - :pattern: (\d)(\d{3})(\d{3,4})
     :leadingDigits: 1|2[45]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (2)(\d{4})(\d{4})
     :leadingDigits: '251'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d)(\d{2})(\d{3})
     :leadingDigits: 16|2
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3,4})
     :leadingDigits: 67|81
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{3,4})
-    :leadingDigits: ! '[4-8]'
-    :format: $1$2$3
+    :leadingDigits: '[4-8]'
+    :format: $1 $2 $3
   - :pattern: (9)(\d{3})(\d{4,5})
     :leadingDigits: 9(?:[235-9]|4[13789])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (9)(4\d{4})(\d{4})
     :leadingDigits: 94[0245]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: MN
   :countryCode: '976'
   :internationalPrefix: '001'
@@ -5020,10 +5020,10 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[12]\d{7,9}|[57-9]\d{7}'
+      :nationalNumberPattern: '[12]\d{7,9}|[57-9]\d{7}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
-      :nationalNumberPattern: ! '[12](?:1\d|2(?:[1-3]\d?|7\d)|3[2-8]\d{1,2}|4[2-68]\d{1,2}|5[1-4689]\d{1,2})\d{5}|5[0568]\d{6}'
+      :nationalNumberPattern: '[12](?:1\d|2(?:[1-3]\d?|7\d)|3[2-8]\d{1,2}|4[2-68]\d{1,2}|5[1-4689]\d{1,2})\d{5}|5[0568]\d{6}'
       :exampleNumber: '50123456'
     :mobile:
       :nationalNumberPattern: (?:8[89]|9[013-9])\d{6}
@@ -5035,27 +5035,27 @@
       :exampleNumber: '75123456'
   :formats:
   - :pattern: ([12]\d)(\d{2})(\d{4})
-    :leadingDigits: ! '[12]1'
-    :format: $1$2$3
+    :leadingDigits: '[12]1'
+    :format: $1 $2 $3
   - :pattern: ([12]2\d)(\d{5,6})
-    :leadingDigits: ! '[12]2[1-3]'
-    :format: $1$2
+    :leadingDigits: '[12]2[1-3]'
+    :format: $1 $2
   - :pattern: ([12]\d{3})(\d{5})
-    :leadingDigits: ! '[12](?:27|[3-5]\d)2'
-    :format: $1$2
+    :leadingDigits: '[12](?:27|[3-5]\d)2'
+    :format: $1 $2
   - :pattern: (\d{4})(\d{4})
     :nationalPrefixFormattingRule: $FG
-    :leadingDigits: ! '[57-9]'
-    :format: $1$2
+    :leadingDigits: '[57-9]'
+    :format: $1 $2
   - :pattern: ([12]\d{4})(\d{4,5})
-    :leadingDigits: ! '[12](?:27|[3-5]\d)[4-9]'
-    :format: $1$2
+    :leadingDigits: '[12](?:27|[3-5]\d)[4-9]'
+    :format: $1 $2
 - :id: MO
   :countryCode: '853'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[268]\d{7}'
+      :nationalNumberPattern: '[268]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:28[2-57-9]|8[2-57-9]\d)\d{5}
@@ -5065,7 +5065,7 @@
       :exampleNumber: '66123456'
   :formats:
   - :pattern: ([268]\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: MP
   :countryCode: '1'
   :leadingDigits: '670'
@@ -5073,7 +5073,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{9}'
+      :nationalNumberPattern: '[5689]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 670(?:2(?:3[3-7]|56|8[5-8])|32[1238]|4(?:33|8[348])|5(?:32|55|88)|6(?:64|70|82)|78[589]|8[3-9]8|989)\d{4}
@@ -5100,7 +5100,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[56]\d{8}'
+      :nationalNumberPattern: '[56]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 596(?:0[2-5]|[12]0|3[05-9]|4[024-8]|[5-7]\d|89|9[4-8])\d{4}
@@ -5110,13 +5110,13 @@
       :exampleNumber: '696201234'
   :formats:
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: MR
   :countryCode: '222'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-48]\d{7}'
+      :nationalNumberPattern: '[2-48]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 25[08]\d{5}|35\d{6}|45[1-7]\d{5}
@@ -5129,7 +5129,7 @@
       :exampleNumber: '80012345'
   :formats:
   - :pattern: ([2-48]\d)(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: MS
   :countryCode: '1'
   :leadingDigits: '664'
@@ -5137,7 +5137,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{9}'
+      :nationalNumberPattern: '[5689]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 664491\d{4}
@@ -5164,7 +5164,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2357-9]\d{7}'
+      :nationalNumberPattern: '[2357-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:0(?:1[0-6]|[69]\d)|[1-357]\d{2})\d{4}
@@ -5189,14 +5189,14 @@
       :exampleNumber: '50112345'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: MU
   :countryCode: '230'
   :internationalPrefix: 0(?:0|[2-7]0|33)
   :preferredInternationalPrefix: '020'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{6,7}'
+      :nationalNumberPattern: '[2-9]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:[03478]\d|1[0-7]|6[1-69])|4(?:[013568]\d|2[4-7])|5(44\d|471)|6\d{2}|8(?:14|3[129]))\d{4}
@@ -5219,18 +5219,18 @@
       :exampleNumber: '3201234'
   :formats:
   - :pattern: ([2-46-9]\d{2})(\d{4})
-    :leadingDigits: ! '[2-46-9]'
-    :format: $1$2
+    :leadingDigits: '[2-46-9]'
+    :format: $1 $2
   - :pattern: (5\d{3})(\d{4})
     :leadingDigits: '5'
-    :format: $1$2
+    :format: $1 $2
 - :id: MV
   :countryCode: '960'
   :internationalPrefix: 0(?:0|19)
   :preferredInternationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3467]\d{6}|9(?:00\d{7}|\d{6})'
+      :nationalNumberPattern: '[3467]\d{6}|9(?:00\d{7}|\d{6})'
       :possibleNumberPattern: \d{7,10}
     :fixedLine:
       :nationalNumberPattern: (?:3(?:0[01]|3[0-59])|6(?:[567][02468]|8[024689]|90))\d{4}
@@ -5250,11 +5250,11 @@
       :exampleNumber: '9001234567'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[3467]|9(?:[1-9]|0[1-9])'
+    :leadingDigits: '[3467]|9(?:[1-9]|0[1-9])'
     :format: $1-$2
   - :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: '900'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: MW
   :countryCode: '265'
   :internationalPrefix: '00'
@@ -5274,13 +5274,13 @@
   :formats:
   - :pattern: (\d)(\d{3})(\d{3})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (2\d{2})(\d{3})(\d{3})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[1789]'
-    :format: $1$2$3$4
+    :leadingDigits: '[1789]'
+    :format: $1 $2 $3 $4
 - :id: MX
   :countryCode: '52'
   :internationalPrefix: 0[09]
@@ -5293,7 +5293,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{9,10}'
+      :nationalNumberPattern: '[1-9]\d{9,10}'
       :possibleNumberPattern: \d{7,11}
     :fixedLine:
       :nationalNumberPattern: (?:33|55|81)\d{8}|(?:2(?:2[2-9]|3[1-35-8]|4[13-9]|7[1-689]|8[1-578]|9[467])|3(?:1[1-79]|[2458][1-9]|7[1-8]|9[1-5])|4(?:1[1-57-9]|[24-6][1-9]|[37][1-8]|8[1-35-9]|9[2-689])|5(?:88|9[1-79])|6(?:1[2-68]|[234][1-9]|5[1-3689]|6[12457-9]|7[1-7]|8[67]|9[4-8])|7(?:[13467][1-9]|2[1-8]|5[13-9]|8[1-69]|9[17])|8(?:2[13-689]|3[1-6]|4[124-6]|6[1246-9]|7[1-378]|9[12479])|9(?:1[346-9]|2[1-4]|3[2-46-8]|5[1348]|[69][1-9]|7[12]|8[1-8]))\d{7}
@@ -5314,20 +5314,20 @@
   :formats:
   - :pattern: ([358]\d)(\d{4})(\d{4})
     :leadingDigits: 33|55|81
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{4})
-    :leadingDigits: ! '[2467]|3[12457-9]|5[89]|8[02-9]|9[0-35-9]'
-    :format: $1$2$3
+    :leadingDigits: '[2467]|3[12457-9]|5[89]|8[02-9]|9[0-35-9]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1)([358]\d)(\d{4})(\d{4})
     :leadingDigits: 1(?:33|55|81)
-    :format: 044$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: 044 $2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1)(\d{3})(\d{3})(\d{4})
     :leadingDigits: 1(?:[2467]|3[12457-9]|5[89]|8[2-9]|9[1-35-9])
-    :format: 044$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: 044 $2 $3 $4
+    :intlFormat: $1 $2 $3 $4
 - :id: MY
   :countryCode: '60'
   :internationalPrefix: '00'
@@ -5335,7 +5335,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[13-9]\d{7,9}'
+      :nationalNumberPattern: '[13-9]\d{7,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: (?:3[2-9]\d|[4-9][2-9])\d{6}
@@ -5364,33 +5364,33 @@
   :formats:
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([4-79])(\d{3})(\d{4})
-    :leadingDigits: ! '[4-79]'
-    :format: $1-$2$3
+    :leadingDigits: '[4-79]'
+    :format: $1-$2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (3)(\d{4})(\d{4})
     :leadingDigits: '3'
-    :format: $1-$2$3
+    :format: $1-$2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: ([18]\d)(\d{3})(\d{3,4})
     :leadingDigits: 1[02-46-9][1-9]|8
-    :format: $1-$2$3
+    :format: $1-$2 $3
   - :pattern: (1)([36-8]00)(\d{2})(\d{4})
     :leadingDigits: 1[36-8]0
     :format: $1-$2-$3-$4
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (11)(\d{4})(\d{4})
     :leadingDigits: '11'
-    :format: $1-$2$3
+    :format: $1-$2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (15[49])(\d{3})(\d{4})
     :leadingDigits: '15'
-    :format: $1-$2$3
+    :format: $1-$2 $3
 - :id: MZ
   :countryCode: '258'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[28]\d{7,8}'
+      :nationalNumberPattern: '[28]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
       :nationalNumberPattern: 2(?:[1346]\d|5[0-2]|[78][12]|93)\d{5}
@@ -5407,10 +5407,10 @@
   :formats:
   - :pattern: ([28]\d)(\d{3})(\d{3,4})
     :leadingDigits: 2|8[246]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (80\d)(\d{3})(\d{3})
     :leadingDigits: '80'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: NA
   :countryCode: '264'
   :internationalPrefix: '00'
@@ -5418,7 +5418,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[68]\d{7,8}'
+      :nationalNumberPattern: '[68]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
       :nationalNumberPattern: 6(?:1(?:17|2(?:[0189]\d|[2-6]|7\d?)|3(?:2\d|3[378])|4[01]|69|7[014])|2(?:17|25|5(?:[0-36-8]|4\d?)|69|70)|3(?:17|2(?:[0237]\d?|[14-689])|34|6[29]|7[01]|81)|4(?:17|2(?:[012]|7?)|4(?:[06]|1\d)|5(?:[01357]|[25]\d?)|69|7[01])|5(?:17|2(?:[0459]|[23678]\d?)|69|7[01])|6(?:17|2(?:5|6\d?)|38|42|69|7[01])|7(?:17|2(?:[569]|[234]\d?)|3(?:0\d?|[13])|69|7[01]))\d{4}
@@ -5437,22 +5437,22 @@
   :formats:
   - :pattern: (8\d)(\d{3})(\d{4})
     :leadingDigits: 8[1235]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6\d)(\d{2,3})(\d{4})
     :leadingDigits: '6'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (88)(\d{3})(\d{3})
     :leadingDigits: '88'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (870)(\d{3})(\d{3})
     :leadingDigits: '870'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: NC
   :countryCode: '687'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57-9]\d{5}'
+      :nationalNumberPattern: '[2-57-9]\d{5}'
       :possibleNumberPattern: \d{6}
     :fixedLine:
       :nationalNumberPattern: (?:2[03-9]|3[0-5]|4[1-7]|88)\d{4}
@@ -5466,7 +5466,7 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})
     :comment: ''
-    :leadingDigits: ! '[2-46-9]|5[0-4]'
+    :leadingDigits: '[2-46-9]|5[0-4]'
     :format: $1.$2.$3
 - :id: NE
   :countryCode: '227'
@@ -5474,7 +5474,7 @@
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[0289]\d{7}'
+      :nationalNumberPattern: '[0289]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:0(?:20|3[1-7]|4[134]|5[14]|6[14578]|7[1-578])|1(?:4[145]|5[14]|6[14-68]|7[169]|88))\d{4}
@@ -5490,17 +5490,17 @@
       :exampleNumber: 09123456
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[289]|09'
-    :format: $1$2$3$4
+    :leadingDigits: '[289]|09'
+    :format: $1 $2 $3 $4
   - :pattern: (08)(\d{3})(\d{3})
     :leadingDigits: 08
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: NF
   :countryCode: '672'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[13]\d{5}'
+      :nationalNumberPattern: '[13]\d{5}'
       :possibleNumberPattern: \d{5,6}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:06|17|28|39)|3[012]\d)\d{3}
@@ -5511,10 +5511,10 @@
   :formats:
   - :pattern: (\d{2})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d)(\d{5})
     :leadingDigits: '3'
-    :format: $1$2
+    :format: $1 $2
 - :id: NG
   :countryCode: '234'
   :internationalPrefix: 009
@@ -5523,10 +5523,10 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-69]\d{5,8}|[78]\d{5,13}'
+      :nationalNumberPattern: '[1-69]\d{5,8}|[78]\d{5,13}'
       :possibleNumberPattern: \d{5,14}
     :fixedLine:
-      :nationalNumberPattern: ! '[12]\d{6,7}|9\d{7}|(?:3\d|4[023568]|5[02368]|6[02-469]|7[4-69]|8[2-9])\d{6}|(?:4[47]|5[14579]|6[1578]|7[0-357])\d{5,6}|(?:78|41)\d{5}'
+      :nationalNumberPattern: '[12]\d{6,7}|9\d{7}|(?:3\d|4[023568]|5[02368]|6[02-469]|7[4-69]|8[2-9])\d{6}|(?:4[47]|5[14579]|6[1578]|7[0-357])\d{5,6}|(?:78|41)\d{5}'
       :possibleNumberPattern: \d{5,9}
       :exampleNumber: '12345678'
     :mobile:
@@ -5543,29 +5543,29 @@
       :exampleNumber: '7001234567'
   :formats:
   - :pattern: ([129])(\d{3})(\d{3,4})
-    :leadingDigits: ! '[129]'
-    :format: $1$2$3
+    :leadingDigits: '[129]'
+    :format: $1 $2 $3
   - :pattern: ([3-8]\d)(\d{3})(\d{2,3})
-    :leadingDigits: ! '[3-6]|7(?:[1-79]|0[1-9])|8[2-9]'
-    :format: $1$2$3
+    :leadingDigits: '[3-6]|7(?:[1-79]|0[1-9])|8[2-9]'
+    :format: $1 $2 $3
   - :pattern: ([78]\d{2})(\d{3})(\d{3,4})
     :leadingDigits: 70|8[01]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([78]00)(\d{4})(\d{4,5})
-    :leadingDigits: ! '[78]00'
-    :format: $1$2$3
+    :leadingDigits: '[78]00'
+    :format: $1 $2 $3
   - :pattern: ([78]00)(\d{5})(\d{5,6})
-    :leadingDigits: ! '[78]00'
-    :format: $1$2$3
+    :leadingDigits: '[78]00'
+    :format: $1 $2 $3
   - :pattern: (78)(\d{2})(\d{3})
     :leadingDigits: '78'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: NI
   :countryCode: '505'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1258]\d{7}'
+      :nationalNumberPattern: '[1258]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2\d{7}
@@ -5578,7 +5578,7 @@
       :exampleNumber: '18001234'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: NL
   :countryCode: '31'
   :internationalPrefix: '00'
@@ -5623,23 +5623,23 @@
   :formats:
   - :pattern: ([1-578]\d)(\d{3})(\d{4})
     :leadingDigits: 1[035]|2[0346]|3[03568]|4[0356]|5[0358]|7|8[4578]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([1-5]\d{2})(\d{3})(\d{3})
     :leadingDigits: 1[16-8]|2[259]|3[124]|4[17-9]|5[124679]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (6)(\d{8})
     :leadingDigits: 6[0-57-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (66)(\d{7})
     :leadingDigits: '66'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (14)(\d{3,4})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '14'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([89]0\d)(\d{4,7})
     :leadingDigits: 80|9
-    :format: $1$2
+    :format: $1 $2
 - :id: 'NO'
   :countryCode: '47'
   :internationalPrefix: '00'
@@ -5687,11 +5687,11 @@
       :exampleNumber: '81212345'
   :formats:
   - :pattern: ([489]\d{2})(\d{2})(\d{3})
-    :leadingDigits: ! '[489]'
-    :format: $1$2$3
+    :leadingDigits: '[489]'
+    :format: $1 $2 $3
   - :pattern: ([235-7]\d)(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[235-7]'
-    :format: $1$2$3$4
+    :leadingDigits: '[235-7]'
+    :format: $1 $2 $3 $4
 - :id: NP
   :countryCode: '977'
   :internationalPrefix: '00'
@@ -5699,7 +5699,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-8]\d{7}|9(?:[1-69]\d{6}|7[2-6]\d{5,7}|8\d{8})'
+      :nationalNumberPattern: '[1-8]\d{7}|9(?:[1-69]\d{6}|7[2-6]\d{5,7}|8\d{8})'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: (?:1[0124-6]|2[13-79]|3[135-8]|4[146-9]|5[135-7]|6[13-9]|7[15-9]|8[1-46-9]|9[1-79])\d{6}
@@ -5724,7 +5724,7 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[458]\d{6}'
+      :nationalNumberPattern: '[458]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: (?:444|888)\d{4}
@@ -5734,19 +5734,19 @@
       :exampleNumber: '5551234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: NU
   :countryCode: '683'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-5]\d{3}'
+      :nationalNumberPattern: '[1-5]\d{3}'
       :possibleNumberPattern: \d{4}
     :fixedLine:
-      :nationalNumberPattern: ! '[34]\d{3}'
+      :nationalNumberPattern: '[34]\d{3}'
       :exampleNumber: '4002'
     :mobile:
-      :nationalNumberPattern: ! '[125]\d{3}'
+      :nationalNumberPattern: '[125]\d{3}'
       :exampleNumber: '1234'
 - :id: NZ
   :countryCode: '64'
@@ -5768,7 +5768,7 @@
       :possibleNumberPattern: \d{8,10}
       :exampleNumber: '211234567'
     :pager:
-      :nationalNumberPattern: ! '[28]6\d{6,7}'
+      :nationalNumberPattern: '[28]6\d{6,7}'
       :possibleNumberPattern: \d{8,9}
       :exampleNumber: '26123456'
     :tollFree:
@@ -5781,24 +5781,24 @@
       :exampleNumber: '900123456'
   :formats:
   - :pattern: ([34679])(\d{3})(\d{4})
-    :leadingDigits: ! '[3467]|9[1-9]'
-    :format: $1-$2$3
+    :leadingDigits: '[3467]|9[1-9]'
+    :format: $1-$2 $3
   - :pattern: (24099)(\d{3})
     :leadingDigits: '24099'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{3})(\d{3})
     :leadingDigits: '21'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{3,4})
     :leadingDigits: 2(?:1[1-9]|[69]|7[0-35-9])|86
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (2\d)(\d{3,4})(\d{4})
     :leadingDigits: 2[028]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{3,4})
     :comment: ''
     :leadingDigits: 2(?:10|74)|5|[89]0
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: OM
   :countryCode: '968'
   :internationalPrefix: '00'
@@ -5822,20 +5822,20 @@
   :formats:
   - :pattern: (2\d)(\d{6})
     :leadingDigits: '2'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (9\d{3})(\d{4})
     :leadingDigits: '9'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([58]00)(\d{4,6})
-    :leadingDigits: ! '[58]'
-    :format: $1$2
+    :leadingDigits: '[58]'
+    :format: $1 $2
 - :id: PA
   :countryCode: '507'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{6,7}'
+      :nationalNumberPattern: '[1-9]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:0[02-579]|19|2[37]|3[03]|4[479]|57|65|7[016-8]|8[58]|9[134])|2(?:[0235679]\d|1[0-7]|4[04-9]|8[028])|3(?:0[0-7]|1[14-7]|2[0-3]|3[03]|4[0457]|5[56]|6[068]|7[078]|80|9\d)|4(?:3[013-59]|4\d|7[0-689])|5(?:[01]\d|2[0-7]|[56]0|79)|7(?:0[09]|2[0-267]|[349]0|5[6-9]|7[0-24-7]|8[89])|8(?:[34]\d|5[0-4]|8[02])|9(?:0[78]|1[0178]|2[0378]|3[379]|40|5[0489]|6[06-9]|7[046-9]|8[36-8]|9[1-9]))\d{4}
@@ -5854,7 +5854,7 @@
       :exampleNumber: '8601234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[1-57-9]'
+    :leadingDigits: '[1-57-9]'
     :format: $1-$2
   - :pattern: (\d{4})(\d{4})
     :leadingDigits: '6'
@@ -5868,7 +5868,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[14-9]\d{7,8}'
+      :nationalNumberPattern: '[14-9]\d{7,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:1\d|4[1-4]|5[1-46]|6[1-7]|7[2-46]|8[2-4])\d{6}
@@ -5897,23 +5897,23 @@
   :formats:
   - :pattern: (1)(\d{7})
     :leadingDigits: '1'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([4-8]\d)(\d{6})
-    :leadingDigits: ! '[4-7]|8[2-4]'
-    :format: $1$2
+    :leadingDigits: '[4-7]|8[2-4]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{5})
     :leadingDigits: '80'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (9\d{2})(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: PF
   :countryCode: '689'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-79]\d{5}|8\d{5,7}'
+      :nationalNumberPattern: '[2-79]\d{5}|8\d{5,7}'
       :possibleNumberPattern: \d{6}(?:\d{2})?
     :noInternationalDialling:
       :nationalNumberPattern: 44\d{4}
@@ -5929,15 +5929,15 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
     :leadingDigits: '89'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: PG
   :countryCode: '675'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{6,7}'
+      :nationalNumberPattern: '[1-9]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:3[0-2]\d|4[25]\d|5[34]\d|64[1-9]|77(?:[0-24]\d|30)|85[02-46-9]|9[78]\d)\d{4}
@@ -5957,11 +5957,11 @@
       :exampleNumber: '2751234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[1-689]'
-    :format: $1$2
+    :leadingDigits: '[1-689]'
+    :format: $1 $2
   - :pattern: (7\d{3})(\d{4})
     :leadingDigits: '7'
-    :format: $1$2
+    :format: $1 $2
 - :id: PH
   :countryCode: '63'
   :internationalPrefix: '00'
@@ -5986,33 +5986,33 @@
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (2)(\d{3})(\d{4})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (2)(\d{5})
     :leadingDigits: '2'
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d{4})(\d{4,6})
     :leadingDigits: 3(?:230|397|461)|4(?:2(?:35|[46]4|51)|396|4(?:22|63)|59[347]|76[15])|5(?:221|446)|642[23]|8(?:622|8(?:[24]2|5[13]))
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d{5})(\d{4})
     :leadingDigits: 3469|4(?:279|9(?:30|56))|8834
-    :format: $1$2
+    :format: $1 $2
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: ([3-8]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[3-8]'
-    :format: $1$2$3
+    :leadingDigits: '[3-8]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{3})(\d{4})
     :leadingDigits: 81|9
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1800)(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (1800)(\d{1,2})(\d{3})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: PK
   :countryCode: '92'
   :internationalPrefix: '00'
@@ -6050,37 +6050,37 @@
   :formats:
   - :pattern: (\d{2})(111)(\d{3})(\d{3})
     :leadingDigits: (?:2[125]|4[0-246-9]|5[1-35-7]|6[1-8]|7[14]|8[16]|91)111
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{3})(111)(\d{3})(\d{3})
     :leadingDigits: (?:2[349]|45|54|60|72|8[2-5]|9[2-9])\d111
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{7,8})
     :leadingDigits: (?:2[125]|4[0-246-9]|5[1-35-7]|6[1-8]|7[14]|8[16]|91)[2-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{6,7})
     :leadingDigits: (?:2[349]|45|54|60|72|8[2-5]|9[2-9])\d[2-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (3\d{2})(\d{7})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: '3'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([15]\d{3})(\d{5,6})
     :leadingDigits: 58[12]|1
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (586\d{2})(\d{5})
     :leadingDigits: '586'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([89]00)(\d{3})(\d{2})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[89]00'
-    :format: $1$2$3
+    :leadingDigits: '[89]00'
+    :format: $1 $2 $3
 - :id: PL
   :countryCode: '48'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-58]\d{6,8}|9\d{8}|[67]\d{5,8}'
+      :nationalNumberPattern: '[1-58]\d{6,8}|9\d{8}|[67]\d{5,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:1[2-8]|2[2-59]|3[2-4]|4[1-468]|5[24-689]|6[1-3578]|7[14-6]|8[1-7])\d{5,7}|77\d{4,7}|(?:89|9[145])\d{7}
@@ -6110,21 +6110,21 @@
       :exampleNumber: '391234567'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[124]|3[2-4]|5[24-689]|6[1-3578]|7[14-7]|8[1-79]|9[145]'
-    :format: $1$2$3$4
+    :leadingDigits: '[124]|3[2-4]|5[24-689]|6[1-3578]|7[14-7]|8[1-79]|9[145]'
+    :format: $1 $2 $3 $4
   - :pattern: (\d{2})(\d{4,6})
     :comment: ''
-    :leadingDigits: ! '[124]|3[2-4]|5[24-689]|6[1-3578]|7[14-7]|8[1-7]'
-    :format: $1$2
+    :leadingDigits: '[124]|3[2-4]|5[24-689]|6[1-3578]|7[14-7]|8[1-7]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{3})
     :leadingDigits: 39|5[013]|6[0469]|7[02389]|8[08]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{2,3})
     :leadingDigits: '64'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})
     :leadingDigits: '64'
-    :format: $1$2
+    :format: $1 $2
 - :id: PM
   :countryCode: '508'
   :internationalPrefix: '00'
@@ -6132,7 +6132,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[45]\d{5}'
+      :nationalNumberPattern: '[45]\d{5}'
       :possibleNumberPattern: \d{6}
     :fixedLine:
       :nationalNumberPattern: 41\d{4}
@@ -6142,7 +6142,7 @@
       :exampleNumber: '551234'
   :formats:
   - :pattern: ([45]\d)(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: PR
   :countryCode: '1'
   :leadingDigits: 787|939
@@ -6150,7 +6150,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5789]\d{9}'
+      :nationalNumberPattern: '[5789]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: (?:787|939)[2-9]\d{6}
@@ -6177,7 +6177,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24589]\d{7,8}|1(?:[78]\d{8}|[49]\d{2,3})'
+      :nationalNumberPattern: '[24589]\d{7,8}|1(?:[78]\d{8}|[49]\d{2,3})'
       :possibleNumberPattern: \d{4,10}
     :fixedLine:
       :nationalNumberPattern: (?:22[234789]|42[45]|82[01458]|92[369])\d{5}
@@ -6201,22 +6201,22 @@
       :exampleNumber: '1700123456'
   :formats:
   - :pattern: ([2489])(2\d{2})(\d{4})
-    :leadingDigits: ! '[2489]'
-    :format: $1$2$3
+    :leadingDigits: '[2489]'
+    :format: $1 $2 $3
   - :pattern: (5[69]\d)(\d{3})(\d{3})
     :leadingDigits: '5'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1[78]00)(\d{3})(\d{3})
     :leadingDigits: 1[78]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: PT
   :countryCode: '351'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-46-9]\d{8}'
+      :nationalNumberPattern: '[2-46-9]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 2(?:[12]\d|[35][1-689]|4[1-59]|6[1-35689]|7[1-9]|8[1-69]|9[1256])\d{6}
@@ -6245,16 +6245,16 @@
   :formats:
   - :pattern: (2\d)(\d{3})(\d{4})
     :leadingDigits: 2[12]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([2-46-9]\d{2})(\d{3})(\d{3})
     :leadingDigits: 2[3-9]|[346-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: PW
   :countryCode: '680'
   :internationalPrefix: 01[12]
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{6}'
+      :nationalNumberPattern: '[2-8]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 2552255|(?:277|345|488|5(?:35|44|87)|6(?:22|54|79)|7(?:33|47)|8(?:24|55|76))\d{4}
@@ -6264,7 +6264,7 @@
       :exampleNumber: '6201234'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: PY
   :countryCode: '595'
   :internationalPrefix: '00'
@@ -6286,42 +6286,42 @@
       :possibleNumberPattern: \d{9}
       :exampleNumber: '870012345'
     :uan:
-      :nationalNumberPattern: ! '[2-9]0\d{4,7}'
+      :nationalNumberPattern: '[2-9]0\d{4,7}'
       :possibleNumberPattern: \d{6,9}
       :exampleNumber: '201234567'
   :formats:
   - :pattern: (\d{2})(\d{5,7})
     :nationalPrefixFormattingRule: ($FG)
     :leadingDigits: (?:[26]1|3[289]|4[124678]|7[123]|8[1236])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3,6})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[2-9]0'
-    :format: $1$2
+    :leadingDigits: '[2-9]0'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{6})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: 9[1-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{3})(\d{4})
     :leadingDigits: '8700'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{4,6})
     :nationalPrefixFormattingRule: ($FG)
-    :leadingDigits: ! '[2-8][1-9]'
-    :format: $1$2
+    :leadingDigits: '[2-8][1-9]'
+    :format: $1 $2
 - :id: QA
   :countryCode: '974'
   :internationalPrefix: '00'
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{6,7}'
+      :nationalNumberPattern: '[2-8]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: 4[04]\d{6}
       :exampleNumber: '44123456'
     :mobile:
-      :nationalNumberPattern: ! '[3567]\d{7}'
+      :nationalNumberPattern: '[3567]\d{7}'
       :exampleNumber: '33123456'
     :pager:
       :nationalNumberPattern: 2(?:[12]\d|61)\d{4}
@@ -6332,11 +6332,11 @@
       :exampleNumber: '8001234'
   :formats:
   - :pattern: ([28]\d{2})(\d{4})
-    :leadingDigits: ! '[28]'
-    :format: $1$2
+    :leadingDigits: '[28]'
+    :format: $1 $2
   - :pattern: ([3-7]\d{3})(\d{4})
-    :leadingDigits: ! '[3-7]'
-    :format: $1$2
+    :leadingDigits: '[3-7]'
+    :format: $1 $2
 - :id: RE
   :countryCode: '262'
   :internationalPrefix: '00'
@@ -6346,7 +6346,7 @@
   :mainCountryForCode: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[268]\d{8}'
+      :nationalNumberPattern: '[268]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 262\d{6}
@@ -6366,7 +6366,7 @@
       :exampleNumber: '810123456'
   :formats:
   - :pattern: ([268]\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: RO
   :countryCode: '40'
   :internationalPrefix: '00'
@@ -6407,18 +6407,18 @@
       :exampleNumber: '372123456'
   :formats:
   - :pattern: ([237]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[23]1'
-    :format: $1$2$3
+    :leadingDigits: '[23]1'
+    :format: $1 $2 $3
   - :pattern: (21)(\d{4})
     :leadingDigits: '21'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{3})
     :comment: ''
-    :leadingDigits: ! '[23][3-7]|[7-9]'
-    :format: $1$2$3
+    :leadingDigits: '[23][3-7]|[7-9]'
+    :format: $1 $2 $3
   - :pattern: (2\d{2})(\d{3})
     :leadingDigits: 2[3-6]
-    :format: $1$2
+    :format: $1 $2
 - :id: RS
   :countryCode: '381'
   :internationalPrefix: '00'
@@ -6427,7 +6427,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[126-9]\d{4,11}|3(?:[0-79]\d{3,10}|8[2-9]\d{2,9})'
+      :nationalNumberPattern: '[126-9]\d{4,11}|3(?:[0-79]\d{3,10}|8[2-9]\d{2,9})'
       :possibleNumberPattern: \d{5,12}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:[02-9][2-9]|1[1-9])\d|2(?:[0-24-7][2-9]\d|[389](?:0[2-9]|[2-9]\d))|3(?:[0-8][2-9]\d|9(?:[2-9]\d|0[2-9])))\d{3,8}
@@ -6452,22 +6452,22 @@
   :formats:
   - :pattern: ([23]\d{2})(\d{4,9})
     :leadingDigits: (?:2[389]|39)0
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([1-3]\d)(\d{5,10})
     :leadingDigits: 1|2(?:[0-24-7]|[389][1-9])|3(?:[0-8]|9[1-9])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (6\d)(\d{6,8})
     :leadingDigits: '6'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([89]\d{2})(\d{3,9})
-    :leadingDigits: ! '[89]'
-    :format: $1$2
+    :leadingDigits: '[89]'
+    :format: $1 $2
   - :pattern: (7[26])(\d{4,9})
     :leadingDigits: 7[26]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (7[08]\d)(\d{4,9})
     :leadingDigits: 7[08]
-    :format: $1$2
+    :format: $1 $2
 - :id: RU
   :countryCode: '7'
   :mainCountryForCode: 'true'
@@ -6478,7 +6478,7 @@
   :nationalPrefixOptionalWhenFormatting: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3489]\d{9}'
+      :nationalNumberPattern: '[3489]\d{9}'
       :possibleNumberPattern: \d{10}
     :fixedLine:
       :nationalNumberPattern: (?:3(?:0[12]|4[1-35-79]|5[1-3]|8[1-58]|9[0145])|4(?:01|1[1356]|2[13467]|7[1-5]|8[1-7]|9[1-689])|8(?:1[1-8]|2[01]|3[13-6]|4[0-8]|5[15]|6[1-35-7]|7[1-37-9]))\d{7}
@@ -6496,15 +6496,15 @@
   - :pattern: (\d{3})(\d{2})(\d{2})
     :nationalPrefixFormattingRule: $FG
     :comment: ''
-    :leadingDigits: ! '[1-79]'
+    :leadingDigits: '[1-79]'
     :format: $1-$2-$3
     :intlFormat: NA
   - :pattern: ([3489]\d{2})(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[34689]'
-    :format: $1$2-$3-$4
+    :leadingDigits: '[34689]'
+    :format: $1 $2-$3-$4
   - :pattern: (7\d{2})(\d{3})(\d{4})
     :leadingDigits: '7'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: RW
   :countryCode: '250'
   :internationalPrefix: '00'
@@ -6512,7 +6512,7 @@
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[027-9]\d{7,8}'
+      :nationalNumberPattern: '[027-9]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
       :nationalNumberPattern: 2[258]\d{7}|06\d{6}
@@ -6533,14 +6533,14 @@
   - :nationalPrefixFormattingRule: $FG
     :pattern: (2\d{2})(\d{3})(\d{3})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([7-9]\d{2})(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[7-9]'
-    :format: $1$2$3
+    :leadingDigits: '[7-9]'
+    :format: $1 $2 $3
   - :pattern: (0\d)(\d{2})(\d{2})(\d{2})
     :leadingDigits: '0'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: SA
   :countryCode: '966'
   :internationalPrefix: '00'
@@ -6569,31 +6569,31 @@
       :exampleNumber: '920012345'
   :formats:
   - :pattern: ([1-467])(\d{3})(\d{4})
-    :leadingDigits: ! '[1-467]'
-    :format: $1$2$3
+    :leadingDigits: '[1-467]'
+    :format: $1 $2 $3
   - :pattern: (1\d)(\d{3})(\d{4})
     :leadingDigits: 1[1-467]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (5\d)(\d{3})(\d{4})
     :leadingDigits: '5'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (92\d{2})(\d{5})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '92'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (800)(\d{3})(\d{4})
     :nationalPrefixFormattingRule: $FG
     :leadingDigits: '80'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (811)(\d{3})(\d{3,4})
     :leadingDigits: '81'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: SB
   :countryCode: '677'
   :internationalPrefix: 0[01]
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{4,6}'
+      :nationalNumberPattern: '[1-9]\d{4,6}'
       :possibleNumberPattern: \d{5,7}
     :fixedLine:
       :nationalNumberPattern: (?:1[4-79]|[23]\d|4[01]|5[03]|6[0-37])\d{3}
@@ -6612,15 +6612,15 @@
       :exampleNumber: '51123'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[7-9]'
-    :format: $1$2
+    :leadingDigits: '[7-9]'
+    :format: $1 $2
 - :id: SC
   :countryCode: '248'
   :internationalPrefix: 0[0-2]
   :preferredInternationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24689]\d{5,6}'
+      :nationalNumberPattern: '[24689]\d{5,6}'
       :possibleNumberPattern: \d{6,7}
     :fixedLine:
       :nationalNumberPattern: 4[2-46]\d{5}
@@ -6644,11 +6644,11 @@
       :exampleNumber: '6412345'
   :formats:
   - :pattern: (\d{3})(\d{3})
-    :leadingDigits: ! '[89]'
-    :format: $1$2
+    :leadingDigits: '[89]'
+    :format: $1 $2
   - :pattern: (\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[246]'
-    :format: $1$2$3
+    :leadingDigits: '[246]'
+    :format: $1 $2 $3
 - :id: SD
   :countryCode: '249'
   :internationalPrefix: '00'
@@ -6656,7 +6656,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[19]\d{8}'
+      :nationalNumberPattern: '[19]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 1(?:[125]\d|8[3567])\d{6}
@@ -6666,7 +6666,7 @@
       :exampleNumber: '911231234'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: SE
   :countryCode: '46'
   :internationalPrefix: '00'
@@ -6675,7 +6675,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-9]\d{5,9}'
+      :nationalNumberPattern: '[1-9]\d{5,9}'
       :possibleNumberPattern: \d{5,10}
     :fixedLine:
       :nationalNumberPattern: 1(?:0[1-8]\d{6}|[136]\d{5,7}|(?:2[0-35]|4[0-4]|5[0-25-9]|7[13-6]|[89]\d)\d{5,6})|2(?:[136]\d{5,7}|(?:2[0-7]|4[0136-8]|5[0138]|7[018]|8[01]|9[0-57])\d{5,6})|3(?:[356]\d{5,7}|(?:0[0-4]|1\d|2[0-25]|4[056]|7[0-2]|8[0-3]|9[023])\d{5,6})|4(?:0[1-9]\d{4,6}|[246]\d{5,7}|(?:1[013-8]|3[0135]|5[14-79]|7[0-246-9]|8[0156]|9[0-689])\d{5,6})|5(?:0[0-6]|[15][0-5]|2[0-68]|3[0-4]|4\d|6[03-5]|7[013]|8[0-79]|9[01])\d{5,6}|6(?:0[1-9]\d{4,6}|3\d{5,7}|(?:1[1-3]|2[0-4]|4[02-57]|5[0-37]|6[0-3]|7[0-2]|8[0247]|9[0-356])\d{5,6})|8[1-9]\d{5,7}|9(?:0[1-9]\d{4,6}|(?:1[0-68]|2\d|3[02-5]|4[0-3]|5[0-4]|[68][01]|7[0135-8])\d{5,6})
@@ -6708,51 +6708,51 @@
   :formats:
   - :pattern: (8)(\d{2,3})(\d{2,3})(\d{2})
     :leadingDigits: '8'
-    :format: $1-$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: $1-$2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :pattern: ([1-69]\d)(\d{2,3})(\d{2})(\d{2})
     :leadingDigits: 1[013689]|2[0136]|3[1356]|4[0246]|54|6[03]|90
-    :format: $1-$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: $1-$2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :pattern: ([1-69]\d)(\d{3})(\d{2})
     :leadingDigits: 1[13689]|2[136]|3[1356]|4[0246]|54|6[03]|90
-    :format: $1-$2$3
-    :intlFormat: $1$2$3
+    :format: $1-$2 $3
+    :intlFormat: $1 $2 $3
   - :pattern: (\d{3})(\d{2})(\d{2})(\d{2})
     :leadingDigits: 1[2457]|2[2457-9]|3[0247-9]|4[1357-9]|5[0-35-9]|6[124-9]|9(?:[125-8]|3[0-5]|4[0-3])
-    :format: $1-$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: $1-$2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :pattern: (\d{3})(\d{2,3})(\d{2})
     :leadingDigits: 1[2457]|2[2457-9]|3[0247-9]|4[1357-9]|5[0-35-9]|6[124-9]|9(?:[125-8]|3[0-5]|4[0-3])
-    :format: $1-$2$3
-    :intlFormat: $1$2$3
+    :format: $1-$2 $3
+    :intlFormat: $1 $2 $3
   - :pattern: (7\d)(\d{3})(\d{2})(\d{2})
     :leadingDigits: '7'
-    :format: $1-$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: $1-$2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :pattern: (77)(\d{2})(\d{2})
     :leadingDigits: '7'
     :format: $1-$2$3
-    :intlFormat: $1$2$3
+    :intlFormat: $1 $2 $3
   - :pattern: (20)(\d{2,3})(\d{2})
     :leadingDigits: '20'
-    :format: $1-$2$3
-    :intlFormat: $1$2$3
+    :format: $1-$2 $3
+    :intlFormat: $1 $2 $3
   - :pattern: (9[034]\d)(\d{2})(\d{2})(\d{3})
     :leadingDigits: 9[034]
-    :format: $1-$2$3$4
-    :intlFormat: $1$2$3$4
+    :format: $1-$2 $3 $4
+    :intlFormat: $1 $2 $3 $4
   - :pattern: (9[034]\d)(\d{4})
     :leadingDigits: 9[034]
     :format: $1-$2
-    :intlFormat: $1$2
+    :intlFormat: $1 $2
 - :id: SG
   :countryCode: '65'
   :internationalPrefix: 0[0-3]\d
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[36]\d{7}|[17-9]\d{7,10}'
+      :nationalNumberPattern: '[36]\d{7}|[17-9]\d{7,10}'
       :possibleNumberPattern: \d{8,11}
     :fixedLine:
       :nationalNumberPattern: 6[1-9]\d{6}
@@ -6780,24 +6780,24 @@
       :exampleNumber: '70001234567'
   :formats:
   - :pattern: ([3689]\d{3})(\d{4})
-    :leadingDigits: ! '[369]|8[1-9]'
-    :format: $1$2
+    :leadingDigits: '[369]|8[1-9]'
+    :format: $1 $2
   - :pattern: (1[89]00)(\d{3})(\d{4})
     :leadingDigits: 1[89]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (7000)(\d{4})(\d{3})
     :leadingDigits: '70'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (800)(\d{3})(\d{4})
     :leadingDigits: '80'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: SH
   :countryCode: '290'
   :internationalPrefix: '00'
   :mainCountryForCode: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-79]\d{3,4}'
+      :nationalNumberPattern: '[2-79]\d{3,4}'
       :possibleNumberPattern: \d{4,5}
     :fixedLine:
       :nationalNumberPattern: 2(?:[0-57-9]\d|6[4-9])\d{2}|(?:[2-46]\d|7[01])\d{2}
@@ -6816,7 +6816,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-7]\d{6,7}|[89]\d{4,7}'
+      :nationalNumberPattern: '[1-7]\d{6,7}|[89]\d{4,7}'
       :possibleNumberPattern: \d{5,8}
     :fixedLine:
       :nationalNumberPattern: (?:1\d|[25][2-8]|3[4-8]|4[24-8]|7[3-8])\d{6}
@@ -6841,17 +6841,17 @@
   :formats:
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d)(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[12]|3[4-8]|4[24-8]|5[2-8]|7[3-8]'
-    :format: $1$2$3$4
+    :leadingDigits: '[12]|3[4-8]|4[24-8]|5[2-8]|7[3-8]'
+    :format: $1 $2 $3 $4
   - :pattern: ([3-7]\d)(\d{3})(\d{3})
-    :leadingDigits: ! '[37][01]|4[019]|51|6'
-    :format: $1$2$3
+    :leadingDigits: '[37][01]|4[019]|51|6'
+    :format: $1 $2 $3
   - :pattern: ([89][09])(\d{3,6})
-    :leadingDigits: ! '[89][09]'
-    :format: $1$2
+    :leadingDigits: '[89][09]'
+    :format: $1 $2
   - :pattern: ([58]\d{2})(\d{5})
     :leadingDigits: 59|8[1-3]
-    :format: $1$2
+    :format: $1 $2
 - :id: SJ
   :countryCode: '47'
   :internationalPrefix: '00'
@@ -6903,14 +6903,14 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-689]\d{8}'
+      :nationalNumberPattern: '[2-689]\d{8}'
       :possibleNumberPattern: \d{9}
     :noInternationalDialling:
       :nationalNumberPattern: (?:8(?:00|[5-9]\d)|9(?:00|[78]\d))\d{6}
       :possibleNumberPattern: \d{9}
       :exampleNumber: '800123456'
     :fixedLine:
-      :nationalNumberPattern: ! '[2-5]\d{8}'
+      :nationalNumberPattern: '[2-5]\d{8}'
       :exampleNumber: '212345678'
     :mobile:
       :nationalNumberPattern: 9(?:0[1-8]|1[0-24-9]|4[0489])\d{6}
@@ -6934,13 +6934,13 @@
   :formats:
   - :pattern: (2)(\d{3})(\d{3})(\d{2})
     :leadingDigits: '2'
-    :format: $1/$2$3$4
+    :format: $1/$2 $3 $4
   - :pattern: ([3-5]\d)(\d{3})(\d{2})(\d{2})
-    :leadingDigits: ! '[3-5]'
-    :format: $1/$2$3$4
+    :leadingDigits: '[3-5]'
+    :format: $1/$2 $3 $4
   - :pattern: ([689]\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[689]'
-    :format: $1$2$3
+    :leadingDigits: '[689]'
+    :format: $1 $2 $3
 - :id: SL
   :countryCode: '232'
   :internationalPrefix: '00'
@@ -6948,17 +6948,17 @@
   :nationalPrefixFormattingRule: ($NP$FG)
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-578]\d{7}'
+      :nationalNumberPattern: '[2-578]\d{7}'
       :possibleNumberPattern: \d{6,8}
     :fixedLine:
-      :nationalNumberPattern: ! '[235]2[2-4][2-9]\d{4}'
+      :nationalNumberPattern: '[235]2[2-4][2-9]\d{4}'
       :exampleNumber: '22221234'
     :mobile:
       :nationalNumberPattern: (?:2[15]|3[034]|4[04]|5[05]|7[6-9]|88)\d{6}
       :exampleNumber: '25123456'
   :formats:
   - :pattern: (\d{2})(\d{6})
-    :format: $1$2
+    :format: $1 $2
 - :id: SM
   :countryCode: '378'
   :internationalPrefix: '00'
@@ -6967,7 +6967,7 @@
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[05-7]\d{7,9}'
+      :nationalNumberPattern: '[05-7]\d{7,9}'
       :possibleNumberPattern: \d{6,10}
     :fixedLine:
       :nationalNumberPattern: 0549(?:8[0157-9]|9\d)\d{4}
@@ -6986,23 +6986,23 @@
       :exampleNumber: '58001110'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :leadingDigits: ! '[5-7]'
-    :format: $1$2$3$4
+    :leadingDigits: '[5-7]'
+    :format: $1 $2 $3 $4
   - :pattern: (0549)(\d{6})
     :leadingDigits: '0'
-    :format: $1$2
+    :format: $1 $2
     :comment: ''
-    :intlFormat: ($1)$2
+    :intlFormat: ($1) $2
   - :pattern: (\d{6})
-    :leadingDigits: ! '[89]'
-    :format: 0549$1
-    :intlFormat: (0549)$1
+    :leadingDigits: '[89]'
+    :format: 0549 $1
+    :intlFormat: (0549) $1
 - :id: SN
   :countryCode: '221'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[37]\d{8}'
+      :nationalNumberPattern: '[37]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 3(?:0(?:1[01]|80)|3(?:8[1-9]|9[2-9]))\d{5}
@@ -7015,14 +7015,14 @@
       :exampleNumber: '333011234'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: SO
   :countryCode: '252'
   :internationalPrefix: '00'
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-79]\d{6,8}'
+      :nationalNumberPattern: '[1-79]\d{6,8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:[134]\d|2[0-79]|5[57-9])\d{5}
@@ -7034,22 +7034,22 @@
   :formats:
   - :pattern: (\d)(\d{6})
     :leadingDigits: 2[0-79]|[13-5]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d)(\d{7})
     :leadingDigits: 24|[67]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{5,7})
     :leadingDigits: 15|28|6[1378]|9
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (69\d)(\d{6})
     :leadingDigits: '69'
-    :format: $1$2
+    :format: $1 $2
 - :id: SR
   :countryCode: '597'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{5,6}'
+      :nationalNumberPattern: '[2-8]\d{5,6}'
       :possibleNumberPattern: \d{6,7}
     :fixedLine:
       :nationalNumberPattern: (?:2[1-3]|3[0-7]|4\d|5[2-58]|68\d)\d{4}
@@ -7064,13 +7064,13 @@
       :exampleNumber: '561234'
   :formats:
   - :pattern: (\d{3})(\d{3})
-    :leadingDigits: ! '[2-4]|5[2-58]'
+    :leadingDigits: '[2-4]|5[2-58]'
     :format: $1-$2
   - :pattern: (\d{2})(\d{2})(\d{2})
     :leadingDigits: '56'
     :format: $1-$2-$3
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[6-8]'
+    :leadingDigits: '[6-8]'
     :format: $1-$2
 - :id: SS
   :countryCode: '211'
@@ -7078,7 +7078,7 @@
   :nationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[19]\d{8}'
+      :nationalNumberPattern: '[19]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 18\d{7}
@@ -7089,13 +7089,13 @@
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $NP$FG
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: ST
   :countryCode: '239'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[29]\d{6}'
+      :nationalNumberPattern: '[29]\d{6}'
       :possibleNumberPattern: \d{7}
     :fixedLine:
       :nationalNumberPattern: 22\d{5}
@@ -7105,20 +7105,20 @@
       :exampleNumber: '9812345'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: SV
   :countryCode: '503'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[267]\d{7}|[89]\d{6}(?:\d{4})?'
+      :nationalNumberPattern: '[267]\d{7}|[89]\d{6}(?:\d{4})?'
       :possibleNumberPattern: \d{7,8}|\d{11}
     :fixedLine:
       :nationalNumberPattern: 2[1-6]\d{6}
       :possibleNumberPattern: \d{8}
       :exampleNumber: '21234567'
     :mobile:
-      :nationalNumberPattern: ! '[67]\d{7}'
+      :nationalNumberPattern: '[67]\d{7}'
       :possibleNumberPattern: \d{8}
       :exampleNumber: '70123456'
     :tollFree:
@@ -7131,14 +7131,14 @@
       :exampleNumber: '9001234'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[267]'
-    :format: $1$2
+    :leadingDigits: '[267]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[89]'
-    :format: $1$2
+    :leadingDigits: '[89]'
+    :format: $1 $2
   - :pattern: (\d{3})(\d{4})(\d{4})
-    :leadingDigits: ! '[89]'
-    :format: $1$2$3
+    :leadingDigits: '[89]'
+    :format: $1 $2 $3
 - :id: SX
   :countryCode: '1'
   :leadingDigits: '721'
@@ -7146,7 +7146,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5789]\d{9}'
+      :nationalNumberPattern: '[5789]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 7215(?:4[2-8]|8[239]|9[056])\d{4}
@@ -7175,7 +7175,7 @@
   :nationalPrefixOptionalWhenFormatting: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-59]\d{7,8}'
+      :nationalNumberPattern: '[1-59]\d{7,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:1\d?|4\d|[2356])|2[1-35]|3(?:[13]\d|4)|4[13]|5[1-3])\d{6}
@@ -7186,18 +7186,18 @@
       :exampleNumber: '944567890'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{3,4})
-    :leadingDigits: ! '[1-5]'
-    :format: $1$2$3
+    :leadingDigits: '[1-5]'
+    :format: $1 $2 $3
   - :pattern: (9\d{2})(\d{3})(\d{3})
     :leadingDigits: '9'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: SZ
   :countryCode: '268'
   :internationalPrefix: '00'
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[027]\d{7}'
+      :nationalNumberPattern: '[027]\d{7}'
       :possibleNumberPattern: \d{8}
     :noInternationalDialling:
       :nationalNumberPattern: 0800\d{4}
@@ -7214,8 +7214,8 @@
       :exampleNumber: 08001234
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[027]'
-    :format: $1$2
+    :leadingDigits: '[027]'
+    :format: $1 $2
 - :id: TA
   :countryCode: '290'
   :internationalPrefix: '00'
@@ -7236,7 +7236,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5689]\d{9}'
+      :nationalNumberPattern: '[5689]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 649(?:712|9(?:4\d|50))\d{4}
@@ -7267,7 +7267,7 @@
   :internationalPrefix: 00|16
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2679]\d{7}'
+      :nationalNumberPattern: '[2679]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 22(?:[3789]0|5[0-5]|6[89])\d{4}
@@ -7277,13 +7277,13 @@
       :exampleNumber: '63012345'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: TG
   :countryCode: '228'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[29]\d{7}'
+      :nationalNumberPattern: '[29]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: 2(?:2[2-7]|3[23]|44|55|66|77)\d{5}
@@ -7293,7 +7293,7 @@
       :exampleNumber: '90112345'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: TH
   :countryCode: '66'
   :internationalPrefix: '00'
@@ -7302,7 +7302,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{7,8}|1\d{3}(?:\d{6})?'
+      :nationalNumberPattern: '[2-9]\d{7,8}|1\d{3}(?:\d{6})?'
       :possibleNumberPattern: \d{4}|\d{8,10}
     :noInternationalDialling:
       :nationalNumberPattern: 1\d{3}
@@ -7313,7 +7313,7 @@
       :possibleNumberPattern: \d{8}
       :exampleNumber: '21234567'
     :mobile:
-      :nationalNumberPattern: ! '[89]\d{8}'
+      :nationalNumberPattern: '[89]\d{8}'
       :possibleNumberPattern: \d{9}
       :exampleNumber: '812345678'
     :tollFree:
@@ -7335,14 +7335,14 @@
   :formats:
   - :pattern: (2)(\d{3})(\d{4})
     :leadingDigits: '2'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([3-9]\d)(\d{3})(\d{3,4})
-    :leadingDigits: ! '[3-9]'
-    :format: $1$2$3
+    :leadingDigits: '[3-9]'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1[89]00)(\d{3})(\d{3})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: TJ
   :countryCode: '992'
   :preferredInternationalPrefix: 8~10
@@ -7352,7 +7352,7 @@
   :nationalPrefixOptionalWhenFormatting: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3-59]\d{8}'
+      :nationalNumberPattern: '[3-59]\d{8}'
       :possibleNumberPattern: \d{3,9}
     :fixedLine:
       :nationalNumberPattern: (?:3(?:1[3-5]|2[245]|3[12]|4[24-7]|5[25]|72)|4(?:46|74|87))\d{6}
@@ -7363,36 +7363,36 @@
       :exampleNumber: '917123456'
   :formats:
   - :pattern: ([349]\d{2})(\d{2})(\d{4})
-    :leadingDigits: ! '[34]7|91[78]'
-    :format: $1$2$3
+    :leadingDigits: '[34]7|91[78]'
+    :format: $1 $2 $3
   - :pattern: ([459]\d)(\d{3})(\d{4})
     :leadingDigits: 4[48]|5|9(?:1[59]|[0235-9])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (331700)(\d)(\d{2})
     :leadingDigits: '331700'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{4})(\d)(\d{4})
     :leadingDigits: 3(?:[1245]|3(?:[02-9]|1[0-589]))
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: TK
   :countryCode: '690'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{3}'
+      :nationalNumberPattern: '[2-9]\d{3}'
       :possibleNumberPattern: \d{4}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-4]\d{3}'
+      :nationalNumberPattern: '[2-4]\d{3}'
       :exampleNumber: '3010'
     :mobile:
-      :nationalNumberPattern: ! '[5-9]\d{3}'
+      :nationalNumberPattern: '[5-9]\d{3}'
       :exampleNumber: '5190'
 - :id: TL
   :countryCode: '670'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-489]\d{6}|7\d{6,7}'
+      :nationalNumberPattern: '[2-489]\d{6}|7\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: (?:2[1-5]|3[1-9]|4[1-4])\d{5}
@@ -7416,11 +7416,11 @@
       :exampleNumber: '7012345'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[2-489]'
-    :format: $1$2
+    :leadingDigits: '[2-489]'
+    :format: $1 $2
   - :pattern: (\d{4})(\d{4})
     :leadingDigits: '7'
-    :format: $1$2
+    :format: $1 $2
 - :id: TM
   :countryCode: '993'
   :preferredInternationalPrefix: 8~10
@@ -7429,7 +7429,7 @@
   :nationalPrefixFormattingRule: ($NP$FG)
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-6]\d{7}'
+      :nationalNumberPattern: '[1-6]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:2\d|3[1-9])|2(?:22|4[0-35-8])|3(?:22|4[03-9])|4(?:22|3[128]|4\d|6[15])|5(?:22|5[7-9]|6[014-689]))\d{5}
@@ -7440,20 +7440,20 @@
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})(\d{2})
     :leadingDigits: '12'
-    :format: $1$2-$3-$4
+    :format: $1 $2-$3-$4
   - :pattern: (\d{2})(\d{6})
     :nationalPrefixFormattingRule: $NP $FG
     :leadingDigits: '6'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d)(\d{2})(\d{2})
     :leadingDigits: 13|[2-5]
-    :format: $1$2-$3-$4
+    :format: $1 $2-$3-$4
 - :id: TN
   :countryCode: '216'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57-9]\d{7}'
+      :nationalNumberPattern: '[2-57-9]\d{7}'
       :possibleNumberPattern: \d{8}
     :fixedLine:
       :nationalNumberPattern: (?:3[012]|7\d|81)\d{6}
@@ -7466,14 +7466,14 @@
       :exampleNumber: '80123456'
   :formats:
   - :pattern: (\d{2})(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: TO
   :countryCode: '676'
   :internationalPrefix: '00'
   :leadingZeroPossible: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[02-8]\d{4,6}'
+      :nationalNumberPattern: '[02-8]\d{4,6}'
       :possibleNumberPattern: \d{5,7}
     :fixedLine:
       :nationalNumberPattern: (?:2\d|3[1-8]|4[1-4]|[56]0|7[0149]|8[05])\d{3}
@@ -7489,14 +7489,14 @@
       :exampleNumber: 0800222
   :formats:
   - :pattern: (\d{2})(\d{3})
-    :leadingDigits: ! '[1-6]|7[0-4]|8[05]'
+    :leadingDigits: '[1-6]|7[0-4]|8[05]'
     :format: $1-$2
   - :pattern: (\d{3})(\d{4})
     :leadingDigits: 7[5-9]|8[7-9]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{4})(\d{3})
     :leadingDigits: '0'
-    :format: $1$2
+    :format: $1 $2
 - :id: TR
   :countryCode: '90'
   :internationalPrefix: '00'
@@ -7504,7 +7504,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-589]\d{9}|444\d{4}'
+      :nationalNumberPattern: '[2-589]\d{9}|444\d{4}'
       :possibleNumberPattern: \d{7,10}
     :noInternationalDialling:
       :nationalNumberPattern: 444\d{4}
@@ -7538,16 +7538,16 @@
   - :nationalPrefixFormattingRule: ($NP$FG)
     :pattern: (\d{3})(\d{3})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
-    :leadingDigits: ! '[23]|4(?:[0-35-9]|4[0-35-9])'
-    :format: $1$2$3
+    :leadingDigits: '[23]|4(?:[0-35-9]|4[0-35-9])'
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $NP$FG
     :pattern: (\d{3})(\d{3})(\d{4})
     :nationalPrefixOptionalWhenFormatting: 'true'
-    :leadingDigits: ! '[589]'
-    :format: $1$2$3
+    :leadingDigits: '[589]'
+    :format: $1 $2 $3
   - :pattern: (444)(\d{1})(\d{3})
     :leadingDigits: '444'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: TT
   :countryCode: '1'
   :leadingDigits: '868'
@@ -7555,7 +7555,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[589]\d{9}'
+      :nationalNumberPattern: '[589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 868(?:2(?:01|2[1-5])|6(?:07|1[4-6]|2[1-9]|[3-6]\d|7[0-79]|9[0-8])|82[12])\d{4}
@@ -7581,7 +7581,7 @@
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[29]\d{4,5}'
+      :nationalNumberPattern: '[29]\d{4,5}'
       :possibleNumberPattern: \d{5,6}
     :fixedLine:
       :nationalNumberPattern: 2[02-9]\d{3}
@@ -7595,15 +7595,15 @@
   :countryCode: '886'
   :internationalPrefix: 0(?:0[25679]|19)
   :nationalPrefix: '0'
-  :preferredExtnPrefix: ! '#'
+  :preferredExtnPrefix: '#'
   :nationalPrefixFormattingRule: $NP$FG
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{7,8}'
+      :nationalNumberPattern: '[2-9]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
     :fixedLine:
-      :nationalNumberPattern: ! '[2-8]\d{7,8}'
+      :nationalNumberPattern: '[2-8]\d{7,8}'
       :possibleNumberPattern: \d{8,9}
       :exampleNumber: '21234567'
     :mobile:
@@ -7620,11 +7620,11 @@
       :exampleNumber: '900123456'
   :formats:
   - :pattern: ([2-8])(\d{3,4})(\d{4})
-    :leadingDigits: ! '[2-7]|8[1-9]'
-    :format: $1$2$3
+    :leadingDigits: '[2-7]|8[1-9]'
+    :format: $1 $2 $3
   - :pattern: ([89]\d{2})(\d{3})(\d{3})
     :leadingDigits: 80|9
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: TZ
   :countryCode: '255'
   :internationalPrefix: 00[056]
@@ -7660,14 +7660,14 @@
       :exampleNumber: '412345678'
   :formats:
   - :pattern: ([24]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[24]'
-    :format: $1$2$3
+    :leadingDigits: '[24]'
+    :format: $1 $2 $3
   - :pattern: ([67]\d{2})(\d{3})(\d{3})
-    :leadingDigits: ! '[67]'
-    :format: $1$2$3
+    :leadingDigits: '[67]'
+    :format: $1 $2 $3
   - :pattern: ([89]\d{2})(\d{2})(\d{4})
-    :leadingDigits: ! '[89]'
-    :format: $1$2$3
+    :leadingDigits: '[89]'
+    :format: $1 $2 $3
 - :id: UA
   :countryCode: '380'
   :preferredInternationalPrefix: 0~0
@@ -7676,7 +7676,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3-689]\d{8}'
+      :nationalNumberPattern: '[3-689]\d{8}'
       :possibleNumberPattern: \d{5,9}
     :fixedLine:
       :nationalNumberPattern: (?:3[1-8]|4[13-8]|5[1-7]|6[12459])\d{7}
@@ -7699,14 +7699,14 @@
       :exampleNumber: '891234567'
   :formats:
   - :pattern: ([3-689]\d)(\d{3})(\d{4})
-    :leadingDigits: ! '[38]9|4(?:[45][0-5]|87)|5(?:0|6(?:3[14-7]|7)|7[37])|6[36-8]|9[1-9]'
-    :format: $1$2$3
+    :leadingDigits: '[38]9|4(?:[45][0-5]|87)|5(?:0|6(?:3[14-7]|7)|7[37])|6[36-8]|9[1-9]'
+    :format: $1 $2 $3
   - :pattern: ([3-689]\d{2})(\d{3})(\d{3})
     :leadingDigits: 3(?:[1-46-8]2[013-9]|52)|4(?:[1378]2|62[013-9])|5(?:[12457]2|6[24])|6(?:[49]2|[12][29]|5[24])|8[0-8]|90
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([3-6]\d{3})(\d{5})
     :leadingDigits: 3(?:5[013-9]|[1-46-8](?:22|[013-9]))|4(?:[137][013-9]|6(?:[013-9]|22)|[45][6-9]|8[4-6])|5(?:[1245][013-9]|6(?:3[02389]|[015689])|3|7[4-6])|6(?:[49][013-9]|5[0135-9]|[12][13-8])
-    :format: $1$2
+    :format: $1 $2
 - :id: UG
   :countryCode: '256'
   :internationalPrefix: 00[057]
@@ -7734,14 +7734,14 @@
       :exampleNumber: '901123456'
   :formats:
   - :pattern: (\d{3})(\d{6})
-    :leadingDigits: ! '[7-9]|20(?:[013-8]|2[5-9])|4(?:6[45]|[7-9])'
-    :format: $1$2
+    :leadingDigits: '[7-9]|20(?:[013-8]|2[5-9])|4(?:6[45]|[7-9])'
+    :format: $1 $2
   - :pattern: (\d{2})(\d{7})
     :leadingDigits: 3|4(?:[1-5]|6[0-36-9])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (2024)(\d{5})
     :leadingDigits: '2024'
-    :format: $1$2
+    :format: $1 $2
 - :id: US
   :countryCode: '1'
   :internationalPrefix: '011'
@@ -7751,7 +7751,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-9]\d{9}'
+      :nationalNumberPattern: '[2-9]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: (?:2(?:0[1-35-9]|1[02-9]|2[4589]|3[149]|4[08]|5[1-46]|6[0279]|7[026]|8[13])|3(?:0[1-57-9]|1[02-9]|2[0135]|3[014679]|47|5[12]|6[01]|8[056])|4(?:0[124-9]|1[02-579]|2[3-5]|3[0245]|4[0235]|58|69|7[0589]|8[04])|5(?:0[1-57-9]|1[0235-8]|20|3[0149]|4[01]|5[19]|6[1-37]|7[013-5]|8[056])|6(?:0[1-35-9]|1[024-9]|2[036]|3[016]|4[16]|5[017]|6[0-279]|78|8[12])|7(?:0[1-46-8]|1[02-9]|2[047]|3[1247]|4[07]|5[47]|6[02359]|7[02-59]|8[156])|8(?:0[1-68]|1[02-8]|28|3[0-25]|4[3578]|5[06-9]|6[02-5]|7[028])|9(?:0[1346-9]|1[02-9]|2[0589]|3[1678]|4[0179]|5[1246]|7[0-3589]|8[0459]))[2-9]\d{6}
@@ -7776,7 +7776,7 @@
     :format: $1-$2
     :intlFormat: NA
   - :pattern: (\d{3})(\d{3})(\d{4})
-    :format: ($1)$2-$3
+    :format: ($1) $2-$3
     :comment: ''
     :intlFormat: $1-$2-$3
 - :id: UY
@@ -7787,7 +7787,7 @@
   :preferredExtnPrefix: int.
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2489]\d{6,7}'
+      :nationalNumberPattern: '[2489]\d{6,7}'
       :possibleNumberPattern: \d{7,8}
     :fixedLine:
       :nationalNumberPattern: 2\d{7}|4[2-7]\d{6}
@@ -7806,16 +7806,16 @@
       :exampleNumber: '9001234'
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :leadingDigits: ! '[24]'
-    :format: $1$2
+    :leadingDigits: '[24]'
+    :format: $1 $2
   - :pattern: (\d{2})(\d{3})(\d{3})
     :nationalPrefixFormattingRule: $NP$FG
     :leadingDigits: 9[1-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{4})
     :nationalPrefixFormattingRule: $NP$FG
-    :leadingDigits: ! '[89]0'
-    :format: $1$2
+    :leadingDigits: '[89]0'
+    :format: $1 $2
 - :id: UZ
   :countryCode: '998'
   :preferredInternationalPrefix: 8~10
@@ -7824,7 +7824,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[679]\d{8}'
+      :nationalNumberPattern: '[679]\d{8}'
       :possibleNumberPattern: \d{7,9}
     :fixedLine:
       :nationalNumberPattern: (?:6(?:1(?:22|3[124]|4[1-4]|5[123578]|64)|2(?:22|3[0-57-9]|41)|5(?:22|3[3-7]|5[024-8])|6\d{2}|7(?:[23]\d|7[69])|9(?:22|4[1-8]|6[135]))|7(?:0(?:5[4-9]|6[0146]|7[12456]|9[135-8])|1[12]\d|2(?:22|3[1345789]|4[123579]|5[14])|3(?:2\d|3[1578]|4[1-35-7]|5[1-57]|61)|4(?:2\d|3[1-579]|7[1-79])|5(?:22|5[1-9]|6[1457])|6(?:22|3[12457]|4[13-8])|9(?:22|5[1-9])))\d{5}
@@ -7834,7 +7834,7 @@
       :exampleNumber: '912345678'
   :formats:
   - :pattern: ([679]\d)(\d{3})(\d{2})(\d{2})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: VA
   :countryCode: '379'
   :internationalPrefix: '00'
@@ -7851,7 +7851,7 @@
       :possibleNumberPattern: N/A
   :formats:
   - :pattern: (06)(\d{4})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: VC
   :countryCode: '1'
   :leadingDigits: '784'
@@ -7859,7 +7859,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5789]\d{9}'
+      :nationalNumberPattern: '[5789]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 784(?:266|3(?:6[6-9]|7\d|8[0-24-6])|4(?:38|5[0-36-8]|8\d|9[01])|555|638|784)\d{4}
@@ -7888,7 +7888,7 @@
   :carrierCodeFormattingRule: $CC$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[24589]\d{9}'
+      :nationalNumberPattern: '[24589]\d{9}'
       :possibleNumberPattern: \d{7,10}
     :fixedLine:
       :nationalNumberPattern: (?:2(?:12|3[457-9]|[58][1-9]|[467]\d|9[1-6])|50[01])\d{7}
@@ -7915,7 +7915,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2589]\d{9}'
+      :nationalNumberPattern: '[2589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 284(?:(?:229|4(?:22|9[45])|774|8(?:52|6[459]))\d{4}|496[0-5]\d{3})
@@ -7943,7 +7943,7 @@
   :internationalPrefix: '011'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[3589]\d{9}'
+      :nationalNumberPattern: '[3589]\d{9}'
       :possibleNumberPattern: \d{7}(?:\d{3})?
     :fixedLine:
       :nationalNumberPattern: 340(?:2(?:01|2[067]|36|44|77)|3(?:32|44)|4(?:4[38]|7[34])|5(?:1[34]|55)|6(?:26|4[23]|77|9[023])|7(?:[17]\d|27)|884|998)\d{4}
@@ -7971,10 +7971,10 @@
   :nationalPrefixOptionalWhenFormatting: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[17]\d{6,9}|[2-69]\d{7,9}|8\d{6,8}'
+      :nationalNumberPattern: '[17]\d{6,9}|[2-69]\d{7,9}|8\d{6,8}'
       :possibleNumberPattern: \d{7,10}
     :noInternationalDialling:
-      :nationalNumberPattern: ! '[17]99\d{4}|69\d{5,6}'
+      :nationalNumberPattern: '[17]99\d{4}|69\d{5,6}'
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '1992000'
     :fixedLine:
@@ -7994,44 +7994,44 @@
       :possibleNumberPattern: \d{8,10}
       :exampleNumber: '1900123456'
     :uan:
-      :nationalNumberPattern: ! '[17]99\d{4}|69\d{5,6}|80\d{5}'
+      :nationalNumberPattern: '[17]99\d{4}|69\d{5,6}|80\d{5}'
       :possibleNumberPattern: \d{7,8}
       :exampleNumber: '1992000'
   :formats:
   - :pattern: ([17]99)(\d{4})
-    :leadingDigits: ! '[17]99'
-    :format: $1$2
+    :leadingDigits: '[17]99'
+    :format: $1 $2
   - :pattern: ([48])(\d{4})(\d{4})
-    :leadingDigits: ! '[48]'
-    :format: $1$2$3
+    :leadingDigits: '[48]'
+    :format: $1 $2 $3
   - :pattern: ([235-7]\d)(\d{4})(\d{3})
     :leadingDigits: 2[025-79]|3[0136-9]|5[2-9]|6[0-46-8]|7[02-79]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (80)(\d{5})
     :leadingDigits: '80'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (69\d)(\d{4,5})
     :leadingDigits: '69'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([235-7]\d{2})(\d{4})(\d{3})
     :leadingDigits: 2[1348]|3[25]|5[01]|65|7[18]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (9\d)(\d{3})(\d{2})(\d{2})
     :leadingDigits: '9'
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
   - :pattern: (1[2689]\d)(\d{3})(\d{4})
     :leadingDigits: 1(?:[26]|8[68]|99)
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :nationalPrefixFormattingRule: $FG
     :pattern: (1[89]00)(\d{4,6})
     :leadingDigits: 1[89]0
-    :format: $1$2
+    :format: $1 $2
 - :id: VU
   :countryCode: '678'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-57-9]\d{4,6}'
+      :nationalNumberPattern: '[2-57-9]\d{4,6}'
       :possibleNumberPattern: \d{5,7}
     :fixedLine:
       :nationalNumberPattern: (?:2[2-9]\d|3(?:[5-7]\d|8[0-8])|48[4-9]|88\d)\d{2}
@@ -8047,14 +8047,14 @@
       :exampleNumber: '30123'
   :formats:
   - :pattern: (\d{3})(\d{4})
-    :leadingDigits: ! '[579]'
-    :format: $1$2
+    :leadingDigits: '[579]'
+    :format: $1 $2
 - :id: WF
   :countryCode: '681'
   :internationalPrefix: '00'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[5-7]\d{5}'
+      :nationalNumberPattern: '[5-7]\d{5}'
       :possibleNumberPattern: \d{6}
     :fixedLine:
       :nationalNumberPattern: (?:50|68|72)\d{4}
@@ -8064,13 +8064,13 @@
       :exampleNumber: '501234'
   :formats:
   - :pattern: (\d{2})(\d{2})(\d{2})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: WS
   :countryCode: '685'
   :internationalPrefix: '0'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[2-8]\d{4,6}'
+      :nationalNumberPattern: '[2-8]\d{4,6}'
       :possibleNumberPattern: \d{5,7}
     :fixedLine:
       :nationalNumberPattern: (?:[2-5]\d|6[1-9]|84\d{2})\d{3}
@@ -8087,10 +8087,10 @@
   :formats:
   - :pattern: (8\d{2})(\d{3,4})
     :leadingDigits: '8'
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (7\d)(\d{5})
     :leadingDigits: '7'
-    :format: $1$2
+    :format: $1 $2
 - :id: YE
   :countryCode: '967'
   :internationalPrefix: '00'
@@ -8098,7 +8098,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-7]\d{6,8}'
+      :nationalNumberPattern: '[1-7]\d{6,8}'
       :possibleNumberPattern: \d{6,9}
     :fixedLine:
       :nationalNumberPattern: (?:1(?:7\d|[2-68])|2[2-68]|3[2358]|4[2-58]|5[2-6]|6[3-58]|7[24-68])\d{5}
@@ -8110,11 +8110,11 @@
       :exampleNumber: '712345678'
   :formats:
   - :pattern: ([1-7])(\d{3})(\d{3,4})
-    :leadingDigits: ! '[1-6]|7[24-68]'
-    :format: $1$2$3
+    :leadingDigits: '[1-6]|7[24-68]'
+    :format: $1 $2 $3
   - :pattern: (7\d{2})(\d{3})(\d{3})
     :leadingDigits: 7[0137]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: YT
   :countryCode: '262'
   :internationalPrefix: '00'
@@ -8123,7 +8123,7 @@
   :leadingDigits: 269|63
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[268]\d{8}'
+      :nationalNumberPattern: '[268]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 2696[0-4]\d{4}
@@ -8142,7 +8142,7 @@
   :mobileNumberPortableRegion: 'true'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[1-79]\d{8}|8(?:[067]\d{7}|[1-4]\d{3,7})'
+      :nationalNumberPattern: '[1-79]\d{8}|8(?:[067]\d{7}|[1-4]\d{3,7})'
       :possibleNumberPattern: \d{5,9}
     :fixedLine:
       :nationalNumberPattern: (?:1[0-8]|2[0-378]|3[1-69]|4\d|5[1346-8])\d{7}
@@ -8174,16 +8174,16 @@
   :formats:
   - :pattern: (860)(\d{3})(\d{3})
     :leadingDigits: '860'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3})(\d{4})
-    :leadingDigits: ! '[1-79]|8(?:[0-47]|6[1-9])'
-    :format: $1$2$3
+    :leadingDigits: '[1-79]|8(?:[0-47]|6[1-9])'
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3,4})
     :leadingDigits: 8[1-4]
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{3})(\d{2,3})
     :leadingDigits: 8[1-4]
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: ZM
   :countryCode: '260'
   :internationalPrefix: '00'
@@ -8191,7 +8191,7 @@
   :nationalPrefixFormattingRule: $NP$FG
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[289]\d{8}'
+      :nationalNumberPattern: '[289]\d{8}'
       :possibleNumberPattern: \d{9}
     :fixedLine:
       :nationalNumberPattern: 21[1-8]\d{6}
@@ -8204,11 +8204,11 @@
       :exampleNumber: '800123456'
   :formats:
   - :pattern: ([29]\d)(\d{7})
-    :leadingDigits: ! '[29]'
-    :format: $1$2
+    :leadingDigits: '[29]'
+    :format: $1 $2
   - :pattern: (800)(\d{3})(\d{3})
     :leadingDigits: '8'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: ZW
   :countryCode: '263'
   :internationalPrefix: '00'
@@ -8236,34 +8236,34 @@
   :formats:
   - :pattern: ([49])(\d{3})(\d{2,5})
     :leadingDigits: 4|9[2-9]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([179]\d)(\d{3})(\d{3,4})
-    :leadingDigits: ! '[19]1|7'
-    :format: $1$2$3
+    :leadingDigits: '[19]1|7'
+    :format: $1 $2 $3
   - :pattern: (86\d{2})(\d{3})(\d{3})
     :leadingDigits: 86[24]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([2356]\d{2})(\d{3,5})
     :leadingDigits: 2(?:[278]|0[45]|[49]8)|3(?:08|17|3[78]|[78])|5[15][78]|6(?:[29]8|37|[68][78])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{3})(\d{3})(\d{3,4})
     :leadingDigits: 2(?:[278]|0[45]|48)|3(?:08|17|3[78]|[78])|5[15][78]|6(?:[29]8|37|[68][78])|80
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([1-356]\d)(\d{3,5})
     :leadingDigits: 1[3-9]|2(?:[1-469]|0[0-35-9]|[45][0-79])|3(?:0[0-79]|1[0-689]|[24-69]|3[0-69])|5(?:[02-46-9]|[15][0-69])|6(?:[0145]|[29][0-79]|3[0-689]|[68][0-69])
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([1-356]\d)(\d{3})(\d{3})
     :leadingDigits: 1[3-9]|2(?:[1-469]|0[0-35-9]|[45][0-79])|3(?:0[0-79]|1[0-689]|[24-69]|3[0-69])|5(?:[02-46-9]|[15][0-69])|6(?:[0145]|[29][0-79]|3[0-689]|[68][0-69])
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: ([25]\d{3})(\d{3,5})
     :leadingDigits: 258[23]|5483
-    :format: $1$2
+    :format: $1 $2
   - :pattern: ([25]\d{3})(\d{3})(\d{3})
     :leadingDigits: 258[23]|5483
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (8\d{3})(\d{6})
     :leadingDigits: '86'
-    :format: $1$2
+    :format: $1 $2
 - :id: '001'
   :countryCode: '800'
   :leadingZeroPossible: 'true'
@@ -8282,7 +8282,7 @@
       :nationalNumberPattern: \d{8}
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: '001'
   :countryCode: '808'
   :leadingZeroPossible: 'true'
@@ -8301,12 +8301,12 @@
       :nationalNumberPattern: \d{8}
   :formats:
   - :pattern: (\d{4})(\d{4})
-    :format: $1$2
+    :format: $1 $2
 - :id: '001'
   :countryCode: '870'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[35-7]\d{8}'
+      :nationalNumberPattern: '[35-7]\d{8}'
       :possibleNumberPattern: \d{9}
       :exampleNumber: '301234567'
     :fixedLine:
@@ -8316,7 +8316,7 @@
       :nationalNumberPattern: (?:[356]\d|7[6-8])\d{7}
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: '001'
   :countryCode: '878'
   :types:
@@ -8334,28 +8334,28 @@
       :nationalNumberPattern: 10\d{10}
   :formats:
   - :pattern: (\d{2})(\d{5})(\d{5})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: '001'
   :countryCode: '881'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[67]\d{8}'
+      :nationalNumberPattern: '[67]\d{8}'
       :possibleNumberPattern: \d{9}
       :exampleNumber: '612345678'
     :fixedLine:
       :nationalNumberPattern: NA
       :possibleNumberPattern: NA
     :mobile:
-      :nationalNumberPattern: ! '[67]\d{8}'
+      :nationalNumberPattern: '[67]\d{8}'
   :formats:
   - :pattern: (\d)(\d{3})(\d{5})
-    :leadingDigits: ! '[67]'
-    :format: $1$2$3
+    :leadingDigits: '[67]'
+    :format: $1 $2 $3
 - :id: '001'
   :countryCode: '882'
   :types:
     :generalDesc:
-      :nationalNumberPattern: ! '[13]\d{6,11}'
+      :nationalNumberPattern: '[13]\d{6,11}'
       :possibleNumberPattern: \d{7,12}
       :exampleNumber: '3451234567'
     :fixedLine:
@@ -8373,25 +8373,25 @@
   :formats:
   - :pattern: (\d{2})(\d{4})(\d{3})
     :leadingDigits: 3[23]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{5})
     :leadingDigits: 16|342
-    :format: $1$2
+    :format: $1 $2
   - :pattern: (\d{2})(\d{4})(\d{4})
     :leadingDigits: 34[57]
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{4})(\d{4})
     :leadingDigits: '348'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{2})(\d{4})
     :leadingDigits: '1'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{3,4})(\d{4})
     :leadingDigits: '16'
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{2})(\d{4,5})(\d{5})
     :leadingDigits: '16'
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: '001'
   :countryCode: '883'
   :types:
@@ -8409,9 +8409,9 @@
       :nationalNumberPattern: 51(?:00\d{5}(?:\d{3})?|10\d{8})
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{3})
-    :format: $1$2$3
+    :format: $1 $2 $3
   - :pattern: (\d{3})(\d{3})(\d{3})(\d{3})
-    :format: $1$2$3$4
+    :format: $1 $2 $3 $4
 - :id: '001'
   :countryCode: '888'
   :leadingZeroPossible: 'true'
@@ -8430,7 +8430,7 @@
       :nationalNumberPattern: \d{11}
   :formats:
   - :pattern: (\d{3})(\d{3})(\d{5})
-    :format: $1$2$3
+    :format: $1 $2 $3
 - :id: '001'
   :countryCode: '979'
   :leadingZeroPossible: 'true'
@@ -8449,4 +8449,4 @@
       :nationalNumberPattern: \d{9}
   :formats:
   - :pattern: (\d)(\d{4})(\d{4})
-    :format: $1$2$3
+    :format: $1 $2 $3

--- a/lib/tasks/phonelib_tasks.rake
+++ b/lib/tasks/phonelib_tasks.rake
@@ -51,7 +51,7 @@ namespace :phonelib do
 
                 format.children.each do |f|
                   if f.name != 'text'
-                    current_format[f.name.to_sym] = f.children.first.to_s.tr(" \n", "")
+                    current_format[f.name.to_sym] = f.children.first.to_s.gsub(/\n\s+/, "")
                   end
                 end
 


### PR DESCRIPTION
The current behavior is too aggressive in removing whitespace, causing
spaces in the formatting strings to be removed inappropriately.

This replaces the `tr` call with a more explicit `gsub` targeting the
whitespace eliminations we actually care about.
