### PR TITLE
Minimize the dependency for PhoneValidator

### DIFF
--- a/lib/phonelib.rb
+++ b/lib/phonelib.rb
@@ -8,6 +8,6 @@ module Phonelib
   }
 end
 
-if defined?(Rails)
+if defined?(ActiveModel)
   autoload :PhoneValidator, 'validators/phone_validator'
 end


### PR DESCRIPTION
The `PhoneValidator` should only has the minimal dependency - `ActiveModel`, not the entire `Rails`. 
