### PR TITLE
Get country by attribute *mainCountryForCode*

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -48,7 +48,7 @@ module Phonelib
           valid_countries.detect do |iso2|
             @analyzed_data[iso2][:mainCountryForCode] == "true"
           end
-        end || intermediate[0]
+        end || valid_countries[0]
       end
     end
 


### PR DESCRIPTION
This way it will detect phone "+7 800 550 05 00" as "RU" instead of "KZ".
It will be more compliant with phonelib's demo.
