### PR TITLE
Use type validity for country detection

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -155,10 +155,14 @@ module Phonelib
           next unless /^#{data[:country_code]}#{valid}$/ =~ @sanitized
 
           @national_number = @sanitized[data[:country_code].length..-1]
-          @analyzed_data[data[:id]] = data
-          @analyzed_data[data[:id]][:format] =
-              get_number_format(data[:formats])
-          @analyzed_data[data[:id]].merge! all_number_types(data[:types])
+          types = all_number_types(data[:types])
+          unless types[:valid].empty?
+            
+            @analyzed_data[data[:id]] = data
+            @analyzed_data[data[:id]][:format] =
+                get_number_format(data[:formats])
+            @analyzed_data[data[:id]].merge! types
+          end
         end
       end
     end


### PR DESCRIPTION
Using only the national number regex to detect countries can lead to false positives. For example using 1 514 555 5555 would give the US and Canada as countries, but it is a Canadian number. By making sure there is a valid type for the country this problem appears to be solved.
