### PR TITLE
Correctly handle international numbers

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -164,7 +164,11 @@ module Phonelib
       detected = @@phone_data.find { |data| data[:id] == country }
       if detected
         phone = convert_phone_to_e164(phone, detected)
-        Phonelib::Phone.new(phone, [detected])
+        if phone[0] == '+'
+          Phonelib::Phone.new(phone, @@phone_data)
+        else 
+          Phonelib::Phone.new(phone, [detected])
+        end
       end
     end
 
@@ -181,7 +185,7 @@ module Phonelib
         national_start = 1.upto(3).map {|i| match[i].to_s.length}.inject(:+)
         "#{data[Core::COUNTRY_CODE]}#{phone[national_start..-1]}"
       else
-        phone
+        phone.sub(/^#{data[Core::INTERNATIONAL_PREFIX]}/, '+')
       end
     end
   end


### PR DESCRIPTION
Numbers including the international prefix need to be properly handled
as international calls.

An example would be a German number, dialed from London.

Phonelib.parse('0049032123456789', 'GB')
