### PR TITLE
switch to binread for marshalled data

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -143,7 +143,7 @@ module Phonelib
     # Load data file into memory
     def load_data
       data_file = File.dirname(__FILE__) + '/../../data/phone_data.dat'
-      Marshal.load(File.read(data_file))
+      Marshal.load(File.binread(data_file))
     end
   end
 end

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -306,7 +306,7 @@ describe Phonelib do
   context 'example numbers' do
     it 'is valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'
-      phone_data = Marshal.load(File.read(data_file))
+      phone_data = Marshal.load(File.binread(data_file))
       phone_data.each do |key, data|
         country = data[:id]
         next unless country =~ /[A-Z]{2}/


### PR DESCRIPTION
There is an issue with using IO.read on windows, where data is sometimes truncated, so it's preferable to use IO.binread.
