### PR TITLE
switched checking back to defined? Rails, ActiveModel didn't work in Rails 4.1.4

### DIFF
--- a/lib/phonelib.rb
+++ b/lib/phonelib.rb
@@ -10,4 +10,4 @@ module Phonelib
   }
 end
 
-autoload :PhoneValidator, 'validators/phone_validator' if defined? ActiveModel
+autoload :PhoneValidator, 'validators/phone_validator' if defined? Rails


### PR DESCRIPTION
## PhoneValidator didn't load in Rails 4.1.4.

ActiveModel wasn't defined while phonelib.rb was called, so this condition doesn't pass

``` ruby
autoload :PhoneValidator, 'validators/phone_validator' if defined? ActiveModel
```

Switched checking back to

``` ruby
if defined? Rails
```

as it was before.

This occurred while using the gem in a Rails Engine.
Not sure if there is a better way to solve it, this works well enough for me.
