### PR TITLE
Make #international and #e164 return nil for blank phone numbers

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -124,6 +124,8 @@ module Phonelib
 
     # Returns e164 formatted phone number
     def international
+      sanitized = self.sanitized
+      return nil if sanitized.nil? || sanitized.empty?
       return "+#{sanitized}" unless valid?
 
       format = @data[country][:format]
@@ -139,7 +141,8 @@ module Phonelib
 
     # Returns e164 unformatted phone number
     def e164
-      international.gsub /[^+0-9]/, ''
+      international = self.international
+      international and international.gsub /[^+0-9]/, ''
     end
 
     # Returns whether a current parsed phone number is valid for specified

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -173,6 +173,14 @@ describe Phonelib do
       phone = Phonelib.parse('9721234567')
       expect(phone.international).to eq('+9721234567')
     end
+
+    it 'returns nil when number is nil' do
+      expect(Phonelib.parse(nil).international).to be_nil
+    end
+
+    it 'returns nil when number is empty' do
+      expect(Phonelib.parse('').international).to be_nil
+    end
   end
 
   context '#national' do
@@ -203,6 +211,14 @@ describe Phonelib do
     it 'returns sanitized when number invalid but possible' do
       phone = Phonelib.parse('9721234567')
       expect(phone.e164).to eq('+9721234567')
+    end
+
+    it 'returns nil when number is blank' do
+      expect(Phonelib.parse(nil).e164).to be_nil
+    end
+
+    it 'returns nil when number is empty' do
+      expect(Phonelib.parse('').e164).to be_nil
     end
   end
 
@@ -250,7 +266,7 @@ describe Phonelib do
       expect(phone.country_code).to eq("7")
     end
 
-    it 'retrns nil as coutnry code if no country' do
+    it 'returns nil as country code if no country' do
       phone = Phonelib.parse('7731231234')
       expect(phone.country_code).to be_nil
     end


### PR DESCRIPTION
Issue #41 

Original behaviour:
```
Phonelib.parse(nil).international # => "+"
Phonelib.parse('').international # => "+"
Phonelib.parse(nil).e164 # => "+"
Phonelib.parse('').e164 # => "+"
```

New behaviour:
```
Phonelib.parse(nil).international # => nil
Phonelib.parse('').international # => nil
Phonelib.parse(nil).e164 # => nil
Phonelib.parse('').e164 # => nil
```