### PR TITLE
Improve phonelib performance by adding a regular expression cache

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -9,6 +9,14 @@ module Phonelib
       @@phone_data ||= load_data
     end
 
+    # used to cache frequently-used regular expressions
+    @@phone_regexp_cache = {}
+
+    # getter for phone regexp cache (internal use only)
+    def phone_regexp_cache
+      @@phone_regexp_cache
+    end
+
     # variable for storing geo/carrier/timezone data
     @@phone_ext_data = nil
 

--- a/spec/phonelib_bench.rb
+++ b/spec/phonelib_bench.rb
@@ -1,0 +1,18 @@
+require 'phonelib'
+
+RUNS = Integer(ENV['RUNS'] || 10)
+TEST_NUMBER = ENV['TEST_NUMBER'] || '+18555000000'
+
+def run_benchmark
+  start = Time.now
+  100.times do
+    Phonelib.valid?(TEST_NUMBER)
+  end
+  puts "valid? rate: #{100/(Time.now-start)} calls/s"
+end
+
+puts "Timing phonelib using Ruby #{RUBY_VERSION}"
+
+RUNS.times do
+  run_benchmark
+end


### PR DESCRIPTION
We recently started using `phonelib` to replace `libphonenumber-execjs`, and were hit by some performance issues. Using `ruby-prof` I was able to identify that constant regexp creation is a big bottleneck to `phonelib`, and by adding this simple cache I was able to noticeably improve `phonelib`'s performance.

See the individual commit messages for more details.