### PR TITLE
use "national prefix for parsing" key if it is available for building a valid regex

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -84,6 +84,8 @@ module Phonelib
     POSSIBLE_PATTERN = :possible_number_pattern
     # National prefix key
     NATIONAL_PREFIX = :national_prefix
+    # National prefix for parsing key
+    NATIONAL_PREFIX_FOR_PARSING = :national_prefix_for_parsing
     # National prefix rule key
     NATIONAL_PREFIX_RULE = :national_prefix_formatting_rule
     # Country code key

--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -128,7 +128,7 @@ module Phonelib
                else
                  data[Core::COUNTRY_CODE]
                end
-      regex << "(#{data[Core::NATIONAL_PREFIX]})?"
+      regex << "(#{data[Core::NATIONAL_PREFIX_FOR_PARSING] || data[Core::NATIONAL_PREFIX]})?"
       regex << "(#{data[Core::TYPES][Core::GENERAL][type]})"
 
       cr("^#{regex.join}$")

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -450,6 +450,12 @@ describe Phonelib do
     end
   end
 
+  context 'the country has a specific rule for parsing a national code' do
+    let(:valid_belarus_national_number){ Phonelib.parse('80298570767', 'BY') }
+
+    it { expect(valid_belarus_national_number).to be_valid }
+  end
+
   context 'example numbers' do
     it 'is valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'


### PR DESCRIPTION
Some countries have a specific rule for parsing a national code (see [nationalPrefixForParsing key](https://github.com/googlei18n/libphonenumber/blob/master/resources/PhoneNumberMetadata.xml#L3510)). 