### PR TITLE
Prevent errors being raised from non-string inputs

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -20,7 +20,7 @@ module Phonelib
     #   country (2 letters) like 'US', 'us' or :us for United States
     #
     def initialize(original, country = nil)
-      @original, @extension = separate_extension(original)
+      @original, @extension = separate_extension(original.to_s)
       @extension.gsub!(/[^0-9]/, '') if @extension
 
       if sanitized.empty?

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -701,6 +701,14 @@ describe Phonelib do
     end
   end
 
+  context 'issues ##81' do
+    it 'should not raise errors for non-string inputs' do
+      Phonelib.default_country = :nz
+
+      expect{Phonelib.parse(6421555444)}.to_not raise_error
+    end
+  end
+
   context 'example numbers' do
     it 'are valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'


### PR DESCRIPTION
As per #81 