### PR TITLE
Fix support for strict rails validations

### DIFF
--- a/lib/validators/phone_validator.rb
+++ b/lib/validators/phone_validator.rb
@@ -52,7 +52,7 @@ class PhoneValidator < ActiveModel::EachValidator
               (phone_types(phone) & types).size > 0
             end
 
-    record.errors.add(attribute, options[:message] || :invalid) unless valid
+    record.errors.add(attribute, options[:message] || :invalid, options) unless valid
   end
 
   private

--- a/spec/dummy/app/models/phone.rb
+++ b/spec/dummy/app/models/phone.rb
@@ -1,10 +1,11 @@
 class Phone < ActiveRecord::Base
   attr_accessible :number, :possible_number, :type_number,
-                  :possible_type_number
+                  :possible_type_number, :strict_number
 
   validates :number, phone: true
   validates :possible_number, phone: { possible: true, allow_blank: true }
   validates :type_number, phone: { types: :fixed_line, allow_blank: true }
   validates :possible_type_number, phone: { possible: true, allow_blank: true,
                                             types: [:voip, 'mobile'] }
+  validates :strict_number, phone: { allow_blank: true, strict: true }
 end

--- a/spec/dummy/db/migrate/20161009182201_add_strict_field_to_phone.rb
+++ b/spec/dummy/db/migrate/20161009182201_add_strict_field_to_phone.rb
@@ -1,0 +1,5 @@
+class AddStrictFieldToPhone < ActiveRecord::Migration
+  def change
+    add_column :phones, :strict_number, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -9,17 +9,18 @@
 # from scratch. The latter is a flawed and unsustainable approach (the more migrations
 # you'll amass, the slower it'll run and the greater likelihood for issues).
 #
-# It's strongly recommended to check this file into your version control system.
+# It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20140318165956) do
+ActiveRecord::Schema.define(version: 20161009182201) do
 
-  create_table "phones", :force => true do |t|
+  create_table "phones", force: :cascade do |t|
     t.string   "number"
-    t.datetime "created_at",           :null => false
-    t.datetime "updated_at",           :null => false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.string   "possible_number"
     t.string   "type_number"
     t.string   "possible_type_number"
+    t.string   "strict_number"
   end
 
 end

--- a/spec/dummy/spec/fixtures/phones.yml
+++ b/spec/dummy/spec/fixtures/phones.yml
@@ -30,3 +30,6 @@ possible_type:
 impossible_type:
   number: '972541234567'
   possible_type_number: '97221234567'
+
+invalid_strict:
+  strict_number: '972347'

--- a/spec/dummy/spec/unit/phone_spec.rb
+++ b/spec/dummy/spec/unit/phone_spec.rb
@@ -68,4 +68,10 @@ describe Phone do
     expect(phone.save).to be_false
     expect(phone.errors.any?).to be_true
   end
+
+  it 'should raise ActiveModel::StrictValidationFailed on strict fields' do
+    phone = phones(:invalid_strict)
+    expect{phone.valid?}.to raise_error(ActiveModel::StrictValidationFailed)
+  end
+
 end


### PR DESCRIPTION
Strict rails validation raise an ActiveModel::StrictValidationFailed or
custom exception. By passing the option hash to the errors.add this
functionality is restored.