### PR TITLE
📦 Package only processed files

### DIFF
--- a/phonelib.gemspec
+++ b/phonelib.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     Example: ":tollFree" changed to ":toll_free".
     Please update your app in case you are checking types!
   EOS
-  s.files = Dir['{data,lib,tasks}/**/*'] + %w(MIT-LICENSE Rakefile README.md)
+  s.files = Dir['{lib,tasks}/**/*'] + Dir['data/*.dat'] + %w(MIT-LICENSE Rakefile README.md)
   s.test_files = Dir['test/**/*']
 
   s.add_development_dependency 'rake'


### PR DESCRIPTION
Gems created by previous versions of the gemspec included the large, pre-imported data. This commit ensures only the post-processed data is included, slimming the size of the gem considerably.