### PR TITLE
allow country specification in rails validator

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,9 +48,9 @@ DEPENDENCIES
   phonelib!
   pry
   rack-cache (= 1.2)
-  rake
+  rake (< 11.0)
   rspec (= 2.14.1)
   simplecov
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/lib/validators/phone_validator.rb
+++ b/lib/validators/phone_validator.rb
@@ -43,8 +43,9 @@ class PhoneValidator < ActiveModel::EachValidator
   # Validation method
   def validate_each(record, attribute, value)
     return if options[:allow_blank] && value.blank?
+    country = options[:country_specifier].call(record) if options[:country_specifier]
 
-    phone = parse(value)
+    phone = parse(value, country)
     valid = if simple_validation?
               method = options[:possible] ? :possible? : :valid?
               phone.send(method)

--- a/phonelib.gemspec
+++ b/phonelib.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,tasks}/**/*'] + Dir['data/*.dat'] + %w(MIT-LICENSE Rakefile README.md)
   s.test_files = Dir['test/**/*']
 
-  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rake', '< 11.0'
   s.add_development_dependency 'nokogiri', '= 1.6.0'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'rspec', '= 2.14.1'

--- a/spec/dummy/app/models/phone.rb
+++ b/spec/dummy/app/models/phone.rb
@@ -1,8 +1,8 @@
 class Phone < ActiveRecord::Base
   attr_accessible :number, :possible_number, :type_number,
-                  :possible_type_number, :strict_number
+                  :possible_type_number, :strict_number, :country
 
-  validates :number, phone: true
+  validates :number, phone: { country_specifier: -> phone { phone.country.try(:upcase) } }
   validates :possible_number, phone: { possible: true, allow_blank: true }
   validates :type_number, phone: { types: :fixed_line, allow_blank: true }
   validates :possible_type_number, phone: { possible: true, allow_blank: true,

--- a/spec/dummy/db/migrate/20161230181632_add_country_to_phone.rb
+++ b/spec/dummy/db/migrate/20161230181632_add_country_to_phone.rb
@@ -1,0 +1,5 @@
+class AddCountryToPhone < ActiveRecord::Migration
+  def change
+    add_column :phones, :country, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161009182201) do
+ActiveRecord::Schema.define(version: 20161230181632) do
 
   create_table "phones", force: :cascade do |t|
     t.string   "number"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 20161009182201) do
     t.string   "type_number"
     t.string   "possible_type_number"
     t.string   "strict_number"
+    t.string   "country"
   end
 
 end

--- a/spec/dummy/spec/fixtures/phones.yml
+++ b/spec/dummy/spec/fixtures/phones.yml
@@ -33,3 +33,4 @@ impossible_type:
 
 invalid_strict:
   strict_number: '972347'
+

--- a/spec/dummy/spec/unit/phone_spec.rb
+++ b/spec/dummy/spec/unit/phone_spec.rb
@@ -15,6 +15,20 @@ describe Phone do
     expect(phone.errors.any?).to be_true
   end
 
+  it "is invalid when phone is invalid and country is specified" do
+    phone = Phone.new(number: '1305558858', country: 'us')
+
+    expect(phone.valid?).to be_false
+    expect(phone.errors.any?).to be_true
+  end
+
+  it "is valid when phone is valid and country is specified" do
+    phone = Phone.new(number: '3175082248', country: 'us')
+
+    expect(phone.valid?).to be_true
+    expect(phone.errors.any?).to be_false
+  end
+
   it 'passes when valid' do
     phone = phones(:valid_and_possible)
     expect(phone.save).to be_true


### PR DESCRIPTION
When validating attributes through the rails validator, there is
currently no way to specify a country to validate against. This commit
allows for the passing of a proc that is called during validation to
specify a two letter country code which will then be used during
parsing.

After this commit, validations could look something like this

```
 validates :number, phone: { country_specifier: -> phone { phone.country.try(:upcase) } }
```