### PR TITLE
fixing when not exist geo name value on the data

### DIFF
--- a/lib/phonelib/phone_extended_data.rb
+++ b/lib/phonelib/phone_extended_data.rb
@@ -45,6 +45,7 @@ module Phonelib
       return nil unless ext_data[id_key] > 0
 
       res = Phonelib.phone_ext_data[names_key][ext_data[id_key]]
+      return nil unless res
       res.size == 1 ? res.first : res
     end
 

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -368,6 +368,12 @@ describe Phonelib do
       expect(phone.timezone).to be_nil
       expect(phone.carrier).to be_nil
     end
+
+    it 'should be nil when not exist geo name' do
+      phone = Phonelib.parse('0145-61-1234', 'JP')
+      expect(phone.valid?).to be_true
+      expect(phone.geo_name).to be_nil
+    end
   end
 
   context 'issue #16' do


### PR DESCRIPTION
raise NoMethodError, call geo_name.

ex:
```
[19] pry(main)> a = Phonelib.parse('0145-61-1234', 'JP')
=> #<Phonelib::Phone:0x005579cebced08
 @data=
  {"JP"=>
    {:id=>"JP",
     :country_code=>"81",
     :international_prefix=>"010",
     :national_prefix=>"0",
     :national_prefix_formatting_rule=>"$NP$FG",
     :leading_zero_possible=>"true",
     :mobile_number_portable_region=>"true",
     :national=>"145611234",
     :format=>
      {:pattern=>"(\\d{4})(\\d)(\\d{4})",
       :leading_digits=>
        "1(?:267|3(?:7[247]|9[278])|4(?:5[67]|66)|5(?:47|58|64|8[67])|6(?:3[245]|48|5[4-68]))|5(?:769|979[2-69])|499[2468]|7468|8(?:3(?:8[78]|96[2457-9])|636[2-57-9]|477|51[24])|9(?:496|8
02|9(?:1[23]|69))",
       :format=>"$1-$2-$3"},
     :valid=>[:fixed_line],
     :possible=>[:premium_rate, :personal_number, :uan, :fixed_line]}},
 @extension="",
 @national_number="145611234",
 @original="0145-61-1234",
 @sanitized="0145611234">
[20] pry(main)> a.geo_name
NoMethodError: undefined method `size' for nil:NilClass
from /media/ssd1/tomokane/codes/phonelib/lib/phonelib/phone_extended_data.rb:48:in `get_ext_name'
```

Because this area code geo name has a key on the data but it doesn't have a value.

ex:
https://github.com/googlei18n/libphonenumber/blob/master/resources/geocoding/en/81.txt#L77

I fixed and add spec. Please check it.

Thanks