### PR TITLE
Make `valid_for_country?` checking results consistent when using the instance method or the class method.

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -147,7 +147,8 @@ module Phonelib
     # @return [Boolean] parsed phone number is valid
     def valid_for_country?(country)
       country = country.to_s.upcase
-      @data.find do |iso2, data|
+      tdata = analyze(sanitized, passed_country(country))
+      tdata.find do |iso2, data|
         country == iso2 && data[:valid].any?
       end.is_a? Array
     end

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -924,6 +924,17 @@ describe Phonelib do
     end
   end
 
+  context 'issue #107' do
+    it 'should return consistent results for `valid_for_country?` when using the ' +
+       'instance method or the class method given the same country and phone number' do
+      Phonelib.phone_data.keys.each do |country|
+        expect(Phonelib.valid_for_country?('+9183082081', country)).to(
+          eq(Phonelib.parse('+9183082081').valid_for_country?(country))
+        )
+      end
+    end
+  end
+
   context 'example numbers' do
     it 'are valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'


### PR DESCRIPTION
This should fix #107 by providing consistent result when checking phone validity for certain country with either of the two ways.

```ruby
> my_phone_number = '0251092275';
> phone = Phonelib.parse(my_phone_number);
> phone.valid_for_country? 'FR'
#=> true
> Phonelib.valid_for_country? 'FR'
#=> true
> phone.valid_for_country? 'SG'
#=> false
> Phonelib.valid_for_country? 'SG'
#=> false
```