### PR TITLE
Change example phone_number on ‘issue #107’ spec.

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -147,7 +147,8 @@ module Phonelib
     # @return [Boolean] parsed phone number is valid
     def valid_for_country?(country)
       country = country.to_s.upcase
-      @data.find do |iso2, data|
+      tdata = analyze(sanitized, passed_country(country))
+      tdata.find do |iso2, data|
         country == iso2 && data[:valid].any?
       end.is_a? Array
     end

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -924,6 +924,17 @@ describe Phonelib do
     end
   end
 
+  context 'issue #107' do
+    it 'should return consistent results for `valid_for_country?` when using the ' +
+       'instance method or the class method given the same country and phone number' do
+      Phonelib.phone_data.keys.each do |country|
+        expect(Phonelib.valid_for_country?('+9183082081', country)).to(
+          eq(Phonelib.parse('+9183082081').valid_for_country?(country))
+        )
+      end
+    end
+  end
+
   context 'example numbers' do
     it 'are valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -927,9 +927,10 @@ describe Phonelib do
   context 'issue #107' do
     it 'should return consistent results for `valid_for_country?` when using the ' +
        'instance method or the class method given the same country and phone number' do
+      phone_number = '0251092275'
       Phonelib.phone_data.keys.each do |country|
-        expect(Phonelib.valid_for_country?('+9183082081', country)).to(
-          eq(Phonelib.parse('+9183082081').valid_for_country?(country))
+        expect(Phonelib.valid_for_country?(phone_number, country)).to(
+          eq(Phonelib.parse(phone_number).valid_for_country?(country))
         )
       end
     end


### PR DESCRIPTION
My bad. I was using a phone number that is prefixed with a country code on the test. Therefore, even before the changes I made on `Phone#valid_for_country?`, the code would've passed the test too. Now I've changed the example phone number to the one not prefixed with country code to correctly test the code.