### PR TITLE
Remove unsupported ruby versions and upgrade each minor release to their latest patches.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,12 @@ sudo: false
 cache: bundler
 
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
-  - 2.1.9
   - 2.2.0
-  - 2.2.6
+  - 2.2.8
   - 2.3.1
-  - 2.3.3
+  - 2.3.5
   - 2.4.0
-  - 2.4.1
+  - 2.4.2
 
 gemfile:
   - gemfiles/Gemfile.rails-3.1.x
@@ -40,32 +35,6 @@ after_script:
 
 matrix:
   exclude:
-    - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.rails-4.0.x
-    - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.rails-4.1.x
-    - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.rails-4.2.x
-    - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 1.9.2
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 1.9.3
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.0.0
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.1.0
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.0
-      gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.1.9
-      gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.1.9
-      gemfile: gemfiles/Gemfile.rails-5.1.x
     - rvm: 2.2.0
       gemfile: gemfiles/Gemfile.rails-3.1.x
     - rvm: 2.2.0
@@ -76,15 +45,15 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-5.0.x
     - rvm: 2.2.0
       gemfile: gemfiles/Gemfile.rails-5.1.x
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       gemfile: gemfiles/Gemfile.rails-3.1.x
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       gemfile: gemfiles/Gemfile.rails-3.2.x
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       gemfile: gemfiles/Gemfile.rails-4.0.x
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       gemfile: gemfiles/Gemfile.rails-5.0.x
-    - rvm: 2.2.6
+    - rvm: 2.2.8
       gemfile: gemfiles/Gemfile.rails-5.1.x
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.rails-3.1.x
@@ -92,11 +61,11 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-3.2.x
     - rvm: 2.3.1
       gemfile: gemfiles/Gemfile.rails-4.0.x
-    - rvm: 2.3.3
+    - rvm: 2.3.5
       gemfile: gemfiles/Gemfile.rails-3.1.x
-    - rvm: 2.3.3
+    - rvm: 2.3.5
       gemfile: gemfiles/Gemfile.rails-3.2.x
-    - rvm: 2.3.3
+    - rvm: 2.3.5
       gemfile: gemfiles/Gemfile.rails-4.0.x
     - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.rails-3.1.x
@@ -108,13 +77,13 @@ matrix:
       gemfile: gemfiles/Gemfile.rails-4.1.x
     - rvm: 2.4.0
       gemfile: gemfiles/Gemfile.rails-4.2.x
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       gemfile: gemfiles/Gemfile.rails-3.1.x
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       gemfile: gemfiles/Gemfile.rails-3.2.x
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       gemfile: gemfiles/Gemfile.rails-4.0.x
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       gemfile: gemfiles/Gemfile.rails-4.1.x
-    - rvm: 2.4.1
+    - rvm: 2.4.2
       gemfile: gemfiles/Gemfile.rails-4.2.x


### PR DESCRIPTION
Ruby team has dropped support for version < 2.1 since this April. Removing unsupported ruby versions will alarm and encourage others to upgrade ruby versions in their projects.