### PR TITLE
Allow country_specifier to be set by symbol

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ if mixed with <tt>possible</tt> will check if number is possible for specified t
 <tt>countries: :us</tt> or <tt>countries: [:us, :ca]</tt> - allows to validate against specific countries, 
 if mixed with <tt>possible</tt> will check if number is possible for specified countries
 
-<tt>country_specifier: -> phone { phone.country.try(:upcase) }</tt> - allows to specify country for validation dynamically for each validation. Usefull when phone is stored as national number without country prefix.
+<tt>country_specifier: :method_name</tt> or <tt>country_specifier: -> instance { instance.country.try(:upcase) }</tt> - allows to specify country for validation dynamically for each validation. Usefull when phone is stored as national number without country prefix.
 
 <tt>extensions: false</tt> - set to perform check for phone extension to be blank
 

--- a/lib/validators/phone_validator.rb
+++ b/lib/validators/phone_validator.rb
@@ -92,7 +92,12 @@ class PhoneValidator < ActiveModel::EachValidator
 
   def specified_country(record)
     return unless options[:country_specifier]
-    options[:country_specifier].call(record)
+
+    if options[:country_specifier].is_a?(Symbol)
+      record.send(options[:country_specifier])
+    else
+      options[:country_specifier].call(record)
+    end
   end
 
   # @private

--- a/spec/dummy/app/models/phone.rb
+++ b/spec/dummy/app/models/phone.rb
@@ -4,7 +4,7 @@ class Phone < ActiveRecord::Base
                     :possible_type_number, :strict_number, :country, :type_mobile_number
   end
 
-  validates :number, phone: { country_specifier: -> phone { phone.country.try(:upcase) } }
+  validates :number, phone: { country_specifier: :specify_country }
   validates :possible_number, phone: { possible: true, allow_blank: true }
   validates :type_number, phone: { types: :fixed_line, allow_blank: true }
   validates :possible_type_number, phone: { possible: true, allow_blank: true,
@@ -12,4 +12,10 @@ class Phone < ActiveRecord::Base
   validates :strict_number, phone: { allow_blank: true, strict: true }
   validates :country_number, phone: { allow_blank: true, countries: [:us, :ca] }
   validates :type_mobile_number, phone: { possible: false, allow_blank: true, types: [:mobile] }
+
+  private
+
+  def specify_country
+    country.try(:upcase)
+  end
 end


### PR DESCRIPTION
 Currently you can only use the `country_specifier` option by passing a proc.  This gets overwhelming when the logic is complicated enough to warrant more than a one liner.  I updated the validator so it accepts either a symbol or a proc, which is the generally accepted Rails way.

I also updated the documentation on the proc to be more clear by switching from `phone` to `instance` since it wasn't clear whether a PhoneLib object was being passed or the model instance.

Example:

```ruby
class User < ApplicationRecord
  validated :phone_number, phone: {
    country_specifier: :set_country,
  }

  private

  def set_country
    self.try(:country) || "US"
  end
end