### PR TITLE
Add example for the parse method

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Additionally you can run:
 
 ``` ruby
 phone = Phonelib.parse('123456789')
+phone = Phonelib.parse('+1 (972) 123-4567', 'US')
 ```
 
 You can pass phone number with extension, it should be separated with <tt>;</tt> or <tt>#</tt> signs from the phone number.


### PR DESCRIPTION
I was about to make this method when I found it already exists :smile: 

Looked at the `parse` method in the source code and found this example, putting it in the README/Doc for others who may have the same issue. 