### PR TITLE
Feat/international 00

### DIFF
--- a/lib/phonelib/phone_formatter.rb
+++ b/lib/phonelib/phone_formatter.rb
@@ -66,6 +66,12 @@ module Phonelib
       "#{international}#{formatted_extension}"
     end
 
+    # returns international formatted number with '00' as prefix (instead of '+')
+    # @returns [String] formatted international number with '00' as prefix
+    def international_00
+      e164 && e164.gsub(/[+]/, '00')
+    end
+
     # returns e164 format of phone with extension added
     # @return [String] phone formatted in E164 format with extension
     def full_e164

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -220,6 +220,26 @@ describe Phonelib do
     end
   end
 
+  context '#international_00' do
+    it 'returns the right formatting' do
+      phone = Phonelib.parse('+33601020304')
+      expect(phone.international_00).to eq('0033601020304')
+    end
+
+    it 'returns nil when passed nil' do
+      expect(Phonelib.parse(nil).international_00).to be_nil
+    end
+
+    it 'returns nil when number is empty' do
+      expect(Phonelib.parse('').international_00).to be_nil
+    end
+
+    it 'returns sanitized when number invalid but possible' do
+      phone = Phonelib.parse('9721234567')
+      expect(phone.international_00).to eq('009721234567')
+    end
+  end
+
   context '#national' do
     it 'returns right formatting' do
       phone = Phonelib.parse('972542234567')


### PR DESCRIPTION
### Purpose
Add a formatter method, `#international_00` to display an international number using `00` instead of `+`

### Changes
- add `#international_00` based on `#e164`
- add tests

Fixes #153 