### PR TITLE
Add equality comparison for parsed phone numbers

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -37,6 +37,15 @@ module Phonelib
       valid? ? e164 : original
     end
 
+    # Compare a phone number against a string or other parsed number
+    # @param other [String|Phonelib::Phone] Phone number to compare against
+    # @return [Boolean] result of equality comparison
+    def ==(other)
+      other = Phonelib.parse(other) unless other.is_a?(Phonelib::Phone)
+      return (e164 == other.e164) if valid? && other.valid?
+      original == other.original
+    end
+
     # method to get sanitized phone number (only numbers)
     # @return [String] Sanitized phone number
     def sanitized

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -999,6 +999,39 @@ describe Phonelib do
     end
   end
 
+  # https://github.com/daddyz/phonelib/issues/157
+  describe 'equality' do
+    let(:parsed_number) { Phonelib.parse(raw_number) }
+    let(:raw_number) { '281-330-8004' }
+
+    before { Phonelib.default_country = 'US' }
+    after { Phonelib.default_country = nil }
+
+    context 'when given a number as a string' do
+      it 'is equal' do
+        expect(parsed_number).to eq raw_number
+      end
+    end
+
+    context 'when given identical parsed numbers' do
+      it 'is equal' do
+        expect(parsed_number).to eq Phonelib.parse(raw_number)
+      end
+    end
+
+    context 'when given different representations of the same number' do
+      it 'is equal' do
+        expect(parsed_number).to eq raw_number.tr('-', '')
+      end
+    end
+
+    context 'when given different numbers' do
+      it 'is not equal' do
+        expect(parsed_number).not_to eq '281-330-8005'
+      end
+    end
+  end
+
   context 'valid_country_name method' do
     it 'should not return name for invalid number' do
       phone = Phonelib.parse('+12121231234')


### PR DESCRIPTION
Fixes #157
```ruby
irb(main):012:0> Phonelib.parse('281-330-8004') == Phonelib.parse('281-330-8004')
=> true
irb(main):013:0> Phonelib.parse('281-330-8004') == Phonelib.parse('2813308004')
=> true
irb(main):014:0> Phonelib.parse('281-330-8004') == '2813308004'
=> true
irb(main):015:0> Phonelib.parse('281-330-8004') == Phonelib.parse('281-330-8005')
=> false
```