### PR TITLE
Use https for gem source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     phonelib (0.6.47)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     codeclimate-test-reporter (1.0.8)
       simplecov (<= 0.13)

--- a/gemfiles/Gemfile
+++ b/gemfiles/Gemfile
@@ -1,3 +1,3 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 gemspec :path=>"../"


### PR DESCRIPTION
"https" protocol prefers for security reason.
It prevents impersonation.