### PR TITLE
Add a getter for national_number

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -7,6 +7,9 @@ module Phonelib
     # @!attribute [r] extension
     # @return [String] phone extension passed for parsing after a number
     attr_reader :extension
+    # @!attribute [r] national_number
+    # @return [String] phone national number
+    attr_reader :national_number
 
     # including module that has all phone analyzing methods
     include Phonelib::PhoneAnalyzer


### PR DESCRIPTION
Hi guys. How about exposing national_number as well?

I'm not able to get GB number as I would like to. For example:
```
phone = Phonelib.parse("447415153257")
phone.national # "07415 153257"
```
I would like to have it without the leading 0. Parsing it would cause a  problem when we have other countries like:
```
phone = Phonelib.parse("+22508022052", "CI")
phone.national  # "08 02 20 52"
```
For this one the leading '0' is not optional, without it the number is invalid.

I'm available to improve this PR with your suggestions if you are keen to go along.