### PR TITLE
Fix for ruby 2.7 deprecation warning

### DIFF
--- a/lib/validators/phone_validator.rb
+++ b/lib/validators/phone_validator.rb
@@ -62,7 +62,7 @@ class PhoneValidator < ActiveModel::EachValidator
     @phone = parse(value, specified_country(record))
     valid = phone_valid? && valid_types? && valid_country? && valid_extensions?
 
-    record.errors.add(attribute, message, options) unless valid
+    record.errors.add(attribute, message, **options) unless valid
   end
 
   private


### PR DESCRIPTION
Fixes a deprecation warning introduced by changes in Ruby 2.7 handling of positional vs keyword arguments. I believe this also improves Ruby 3 compatibility since the changes in 2.7 were in preparation for a transition to Ruby 3.

Details: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Fixes #233 

Note: ~~I only tested this against ruby 2.7.  I think this should work transparently under 2.6, but I'm not sure.~~ Looks like CI tests 2.5.x and 2.6.x