### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,9 @@ workflows:
           name: build-v<< matrix.version >>
           matrix:
             parameters:
-              version: ["2.5.9", "2.6.7", "2.7.3", "3.0.1"]
+              version: ["2.5.9", "2.6.7", "2.7.3", "3.0.1", "3.1.0"]
       - build-rails:
           name: build-rails-v<< matrix.version >>
           matrix:
             parameters:
-              version: ["2.5.9", "2.6.7", "2.7.3", "3.0.1"]
+              version: ["2.5.9", "2.6.7", "2.7.3", "3.0.1", "3.1.0"]

--- a/gemfiles/Gemfile.rails-7.0.x
+++ b/gemfiles/Gemfile.rails-7.0.x
@@ -1,0 +1,10 @@
+source "http://rubygems.org"
+
+gem "rails", "~> 7.0.1"
+gem 'rspec-rails', '~> 5.0'
+gem 'rspec', '3.10.0'
+gem "sqlite3", '~> 1.4.2'
+gem "mime-types", "~> 3.3.1"
+gem 'rails-controller-testing'
+
+gemspec :path=>"../"


### PR DESCRIPTION
This PR adds Ruby 3.1 to CI.  It also adds a Rails 7 Gemfile.