### PR TITLE
Only strip 00 prefix when country is not specified

### DIFF
--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -124,6 +124,7 @@ module Phonelib
     #
     # * +phone+ - phone number for parsing
     def detect_and_parse(phone, country)
+      phone.gsub!(/^00/, '')
       result = {}
       Phonelib.phone_data.each do |key, data|
         parsed = parse_single_country(phone, data)

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -81,7 +81,7 @@ module Phonelib
     # * +parsed+ - parsed regex match for phone
     def double_prefix_allowed?(data, phone, parsed = {})
       data[Core::DOUBLE_COUNTRY_PREFIX_FLAG] &&
-        phone =~ cr("^#{data[Core::COUNTRY_CODE]}") &&
+        phone.start_with?(data[Core::COUNTRY_CODE]) &&
         parsed && (parsed[:valid].nil? || parsed[:valid].empty?) &&
         !original_starts_with_plus?
     end
@@ -114,7 +114,6 @@ module Phonelib
     # * +country_optional+ - whether to put country code as optional group
     def full_regex_for_data(data, type, country_optional = true)
       regex = []
-      regex << '0{2}?'
       regex << "(#{data[Core::INTERNATIONAL_PREFIX]})?"
       regex << "(#{data[Core::COUNTRY_CODE]})#{country_optional ? '?' : ''}"
       regex << "(#{data[Core::NATIONAL_PREFIX_FOR_PARSING] || data[Core::NATIONAL_PREFIX]})?"
@@ -144,9 +143,7 @@ module Phonelib
     # * +phone+ - phone number for parsing
     # * +data+  - country data
     def phone_match_data?(phone, data, possible = false)
-      country_code = "#{data[Core::COUNTRY_CODE]}"
-      inter_prefix = "(#{data[Core::INTERNATIONAL_PREFIX]})?"
-      return unless phone.match cr("^0{2}?#{inter_prefix}#{country_code}")
+      return unless phone.start_with?(data[Core::COUNTRY_CODE])
 
       type = possible ? Core::POSSIBLE_PATTERN : Core::VALID_PATTERN
       phone.match full_regex_for_data(data, type, false)


### PR DESCRIPTION
Years ago the company I work for had some performance issues with phonelib (I don't know the details of these problems). We forked the library and made a simple fix. This is an attempt to upstream a modified version of our changes.

The point of this change is to reduce the number of string concatenations.

Two places in code the 00 international prefix is hardcoded in addition to the country-specific international prefixes. As far as I understand, it is only relevant to hardcode this when no country is passed to `Phonelib.parse`. Stripping this prefix in `detect_and_parse` allows us to check for country codes using `start_with?` instead of using regexp built from concatenated strings.


### Benchmark code
```ruby
Phonelib.parse('4571999999')

MemoryProfiler.report do
  40.times { Phonelib.parse('4571999999') }
end.pretty_print
```

#### Results on master
```
$ ruby profile.rb |grep -A7 'allocated objects by clas'
allocated objects by class
-----------------------------------
     61720  String
      1800  Array
       320  MatchData
       200  Hash
        40  Phonelib::Phone
```

#### Results with this PR
```
$ ruby profile.rb |grep -A7 'allocated objects by clas'
allocated objects by class
-----------------------------------
      2440  String
      1800  Array
       280  MatchData
       200  Hash
        40  Phonelib::Phone
```


In addition to the change in stirng allocations, this patch also reduces execution time with about 70%.