### PR TITLE
Allow disabling extension separator

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -178,6 +178,8 @@ module Phonelib
 
     # @private extracts extension from passed phone number if provided
     def separate_extension(original)
+      return [original, ''] unless Phonelib.extension_separate_symbols
+
       regex = if Phonelib.extension_separate_symbols.is_a?(Array)
                 cr("#{Phonelib.extension_separate_symbols.join('|')}")
               else

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -656,6 +656,15 @@ describe Phonelib do
       expect(phone.full_e164).to eq('+972542234567#123')
       expect(phone.full_international).to eq('+972 54-223-4567#123')
     end
+
+    it 'should support nil separator' do
+      Phonelib.extension_separate_symbols = nil
+
+      phone = Phonelib.parse('972542234567#123')
+      expect(phone.original).to eq('972542234567#123')
+      expect(phone.sanitized).to eq('972542234567123')
+      expect(phone.extension).to eq('')
+    end
   end
 
   context 'issue #59' do


### PR DESCRIPTION
In some contexts you don't want to accept numbers with extensions.

This PR allows disabling extensions by setting `Phonelib.extension_separate_symbols = nil`.