### PR TITLE
Add country_code UM to data_importer

### DIFF
--- a/lib/phonelib/data_importer.rb
+++ b/lib/phonelib/data_importer.rb
@@ -45,6 +45,7 @@ module Phonelib
         'TA' => 'SH',
         'TC' => 'US',
         'TT' => 'US',
+        'UM' => 'US',
         'VA' => 'IT',
         'VC' => 'US',
         'VG' => 'US',


### PR DESCRIPTION
The United States Minor Outlying Islands (UM) are using the same phone numbers as the US.