### PR TITLE
Add Phonelib#eager_load! for Rails eager loading

### DIFF
--- a/lib/phonelib.rb
+++ b/lib/phonelib.rb
@@ -17,4 +17,12 @@ if defined?(ActiveModel) || defined?(Rails)
   else
     autoload :PhoneValidator, 'validators/phone_validator'
   end
+
+  if defined?(Rails)
+    class Phonelib::Railtie < Rails::Railtie
+      initializer 'phonelib' do |app|
+        app.config.eager_load_namespaces << Phonelib
+      end
+    end
+  end
 end

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -4,6 +4,13 @@ module Phonelib
     # @private variable will include hash with data for validation
     @@phone_data = nil
 
+    # eagerly initialize the gem, loads data into memory. not required, initialization is done lazily otherwise, but
+    # may be desirable in production enviroments to avoid initialization time on first use.
+    def eager_load!
+      phone_data
+      phone_ext_data
+    end
+
     # getter for phone data for other modules of gem, can be used outside
     # @return [Hash] all data for phone parsing
     def phone_data

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -24,6 +24,10 @@ describe Phonelib do
     expect(Phonelib).to be_a_kind_of(Module)
   end
 
+  it 'responds to eager_load!' do
+    expect{Phonelib.eager_load!}.to_not raise_error
+  end
+
   context '.parse' do
     before(:each) { @phone = Phonelib.parse '9721234567' }
 


### PR DESCRIPTION
Adding `Phonelib.eager_load!` and adding `Phonelib` to `Rails.application.config.eager_load_namespaces` means that in Rails environments that are configured to eager load, Phonelib's data.

I've tested this in a Rails app and it seems to work.