### PR TITLE
Add changelog_uri to gemspec

### DIFF
--- a/phonelib.gemspec
+++ b/phonelib.gemspec
@@ -17,6 +17,10 @@ Gem::Specification.new do |s|
   s.files = Dir['{lib,tasks}/**/*'] + Dir['data/*.dat'] + %w(MIT-LICENSE Rakefile README.md)
   s.test_files = Dir['test/**/*']
 
+  s.metadata = {
+    'changelog_uri' => "#{s.homepage}/releases/tag/v#{s.version}"
+  }
+
   s.add_development_dependency 'rake', '< 14.0'
   if RUBY_VERSION < '2.3.0'
     s.add_development_dependency 'nokogiri', '~> 1.8.2'


### PR DESCRIPTION
Supported here: https://guides.rubygems.org/specification-reference/#metadata Useful for running https://github.com/MaximeD/gem_updater