### PR TITLE
Prepares for Ruby to freeze all strings

### DIFF
--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -23,7 +23,7 @@ module Phonelib
     #   for United States
     # @return [Phonelib::Phone] parsed phone instance
     def initialize(phone, country = nil)
-      @original, @extension = separate_extension(phone.to_s)
+      @original, @extension = separate_extension(phone.to_s).map { |e| +e }
       @extension.gsub!(/[^0-9]/, '') if @extension
 
       if sanitized.empty?

--- a/lib/phonelib/phone_formatter.rb
+++ b/lib/phonelib/phone_formatter.rb
@@ -155,8 +155,8 @@ module Phonelib
       data = @data[country]
       format = data[:format]
       prefix = data[Core::NATIONAL_PREFIX]
-      rule = format[Core::NATIONAL_PREFIX_RULE] ||
-             data[Core::NATIONAL_PREFIX_RULE] || '$1'
+      rule = +(format[Core::NATIONAL_PREFIX_RULE] ||
+              data[Core::NATIONAL_PREFIX_RULE] || '$1')
 
       # change rule's constants to values
       rule.gsub!(/(\$NP|\$FG)/, '$NP' => prefix, '$FG' => '$1')


### PR DESCRIPTION
There was a deprecation warning for chilled strings merged recently in Ruby: https://github.com/ruby/ruby/commit/12be40ae6be78ac41e8e3f3c313cc6f63e7fa6c4

And with that we started to see the following warning coming from `phonelib`:

```
vendor/gems/3.4.0/ruby/3.4.0+0/gems/phonelib-0.8.3/lib/phonelib/phone.rb:27: warning: literal string will be frozen in the future
```

These changes remove those errors by unfreezing strings when they should be mutable. They get the test suite to pass with RUBYOPT="--enable-frozen-string-literal", which will be the default in the future.
