### PR TITLE
Memoize regexp inside PhoneAnalyzer#country_code_candidates_for

### DIFF
--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -139,7 +139,7 @@ module Phonelib
     end
 
     def country_code_candidates_for(phone)
-      stripped_phone = phone.gsub(/^(#{Phonelib.phone_data_int_prefixes})/, '')
+      stripped_phone = phone.gsub(cr("Phonelib.phone_data_int_prefixes") { /^(#{Phonelib.phone_data_int_prefixes})/ }, '')
       ((1..3).map { |length| phone[0, length] } + (1..3).map { |length| stripped_phone[0, length] }).uniq
     end
 

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -52,7 +52,7 @@ module Phonelib
 
     # caches regular expression, reusing it for later lookups
     def cr(regexp)
-      Phonelib.phone_regexp_cache[regexp] ||= Regexp.new(regexp).freeze
+      Phonelib.phone_regexp_cache[regexp] ||= Regexp.new(block_given? ? yield(regexp) : regexp).freeze
     end
 
     # defines whether country can have double country prefix in number


### PR DESCRIPTION
This code path appears in production profiles for us. Local benchmarks shows that It's >80x faster if we memoize the regexp.

<details>

<summary>Benchmark</summary>

```
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) +YJIT [arm64-darwin23]
Warming up --------------------------------------
original_country_code_candidates_for
                         1.491k i/100ms
cached_country_code_candidates_for
                        74.288k i/100ms
smarter_cached_country_code_candidates_for
                       109.646k i/100ms
Calculating -------------------------------------
original_country_code_candidates_for
                         12.539k (± 8.2%) i/s   (79.75 μs/i) -     62.622k in   5.045558s
cached_country_code_candidates_for
                        751.572k (± 4.9%) i/s    (1.33 μs/i) -      3.789M in   5.054955s
smarter_cached_country_code_candidates_for
                          1.087M (± 2.3%) i/s  (920.34 ns/i) -      5.482M in   5.048195s

Comparison:
smarter_cached_country_code_candidates_for:  1086552.9 i/s
cached_country_code_candidates_for:   751571.7 i/s - 1.45x  slower
original_country_code_candidates_for:    12539.3 i/s - 86.65x  slower
```

```ruby
PHONE = "+4623123123"

def original_country_code_candidates_for(phone)
  stripped_phone = phone.gsub(/^(#{Phonelib.phone_data_int_prefixes})/, "")
  ((1..3).map { |length| phone[0, length] } + (1..3).map { |length| stripped_phone[0, length] }).uniq
end

def cached_country_code_candidates_for(phone)
  raw_re = "^(#{Phonelib.phone_data_int_prefixes})"
  re = Phonelib.phone_regexp_cache[raw_re] ||= Regexp.new(raw_re).freeze
  stripped_phone = phone.gsub(re, "")
  ((1..3).map { |length| phone[0, length] } + (1..3).map { |length| stripped_phone[0, length] }).uniq
end

def smarter_cached_country_code_candidates_for(phone)
  re = Phonelib.phone_regexp_cache["phone_data_int_prefixes"] ||= Regexp.new("^(#{Phonelib.phone_data_int_prefixes})").freeze
  stripped_phone = phone.gsub(re, "")
  ((1..3).map { |length| phone[0, length] } + (1..3).map { |length| stripped_phone[0, length] }).uniq
end

Benchmark.ips do |x|
  x.report("original_country_code_candidates_for") { original_country_code_candidates_for(PHONE) }
  x.report("cached_country_code_candidates_for") { cached_country_code_candidates_for(PHONE) }
  x.report("smarter_cached_country_code_candidates_for") { smarter_cached_country_code_candidates_for(PHONE) }
  x.compare!
end
```

</details>