### PR TITLE
Improve phonelib performance by reducing object allocations

### DIFF
--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -202,7 +202,7 @@ module Phonelib
     end
 
     def add_additional_regex(country, type, national_regex)
-      return unless Phonelib::Core::TYPES_DESC.keys.include?(type.to_sym)
+      return unless Phonelib::Core::TYPES_DESC.key?(type.to_sym)
       return unless national_regex.is_a?(String)
       @@phone_data = @@data_by_country_codes = nil
       @@additional_regexes[country.to_s.upcase] ||= {}

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -381,6 +381,7 @@ module Phonelib
       carrier_selection_codes: 'Carrier Selection codes',
       area_code_optional: 'Are code optional'
     }.freeze
+    TYPES_DESC_KEYS = TYPES_DESC.keys.freeze
 
     # @private short codes types keys
     SHORT_CODES = [

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -408,6 +408,10 @@ module Phonelib
     # @private Extended data key for carrier in prefixes hash
     EXT_CARRIER_KEY = :c
 
+    # @private Static arrays used to avoid allocations
+    FIXED_OR_MOBILE_ARRAY = [Core::FIXED_OR_MOBILE].freeze
+    FIXED_LINE_OR_MOBILE_ARRAY = [Core::FIXED_LINE, Core::MOBILE].freeze
+
     # method for parsing phone number.
     # On first run fills @@phone_data with data present in yaml file
     # @param phone [String] the phone number to be parsed

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -411,6 +411,9 @@ module Phonelib
     # @private Static arrays used to avoid allocations
     FIXED_OR_MOBILE_ARRAY = [Core::FIXED_OR_MOBILE].freeze
     FIXED_LINE_OR_MOBILE_ARRAY = [Core::FIXED_LINE, Core::MOBILE].freeze
+    POSSIBLE_VALID_ARRAY = [:possible, :valid].freeze
+    VALID_POSSIBLE_ARRAY = [:valid, :possible].freeze
+    NIL_RESULT_ARRAY = [nil, nil].freeze
 
     # method for parsing phone number.
     # On first run fills @@phone_data with data present in yaml file

--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -33,7 +33,7 @@ module Phonelib
 
     # pick best result when several countries specified
     def pick_results(results)
-      [:valid, :possible].each do |key|
+      Core::VALID_POSSIBLE_ARRAY.each do |key|
         final = results.select { |_k, v| v[key].any? }
         return decorate_analyze_result(final) if final.size > 0
       end
@@ -247,7 +247,7 @@ module Phonelib
           type_regex(patterns, Core::VALID_PATTERN)
         ]
       else
-        [nil, nil]
+        Core::NIL_RESULT_ARRAY
       end
     end
   end

--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -72,7 +72,7 @@ module Phonelib
     def with_replaced_national_prefix(passed_phone, data)
       return passed_phone unless data[Core::NATIONAL_PREFIX_TRANSFORM_RULE]
       phone = if passed_phone.start_with?(data[Core::COUNTRY_CODE]) && !data[Core::DOUBLE_COUNTRY_PREFIX_FLAG]
-                passed_phone.gsub(/^#{data[Core::COUNTRY_CODE]}/, '')
+                passed_phone.delete_prefix(data[Core::COUNTRY_CODE])
               else
                 passed_phone
               end

--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -185,7 +185,7 @@ module Phonelib
       if Phonelib.additional_regexes.is_a?(Hash) && Phonelib.additional_regexes[data[:id]]
         index = Phonelib.additional_regexes[data[:id]].values.flatten.join('|').scan(/\(/).size
       end
-      phone = country_match.to_a[-1 - index]
+      phone = country_match[-1 - index]
       result[:national] = phone
       result[:format] = number_format(phone, data[Core::FORMATS])
       result.merge! all_number_types(phone, data[Core::TYPES], not_valid)

--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -226,7 +226,7 @@ module Phonelib
     def number_format(national, format_data)
       format_data && format_data.find do |format|
         (format[Core::LEADING_DIGITS].nil? || \
-            national.match(cr("^(#{format[Core::LEADING_DIGITS]})"))) && \
+            national.match?(cr("^(#{format[Core::LEADING_DIGITS]})"))) && \
           national.match(cr("^(#{format[Core::PATTERN]})$"))
       end || Core::DEFAULT_NUMBER_FORMAT
     end

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -178,7 +178,7 @@ module Phonelib
     def types_for_check(data)
       exclude_list = PhoneAnalyzer::NOT_FOR_CHECK
       exclude_list += Phonelib::Core::SHORT_CODES unless Phonelib.parse_special
-      Core::TYPES_DESC.keys - exclude_list + fixed_and_mobile_keys(data)
+      Core::TYPES_DESC_KEYS - exclude_list + fixed_and_mobile_keys(data)
     end
 
     # Checks if fixed line pattern and mobile pattern are the same and returns

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -161,10 +161,9 @@ module Phonelib
     # checks if types has both :mobile and :fixed_line and replaces it with
     # :fixed_or_mobile in case both present
     def sanitize_fixed_mobile(types)
-      fixed_mobile = [Core::FIXED_LINE, Core::MOBILE]
       [:possible, :valid].each do |key|
-        if (fixed_mobile - types[key]).empty?
-          types[key] = types[key] - fixed_mobile + [Core::FIXED_OR_MOBILE]
+        if (Core::FIXED_LINE_OR_MOBILE_ARRAY - types[key]).empty?
+          types[key] = types[key] - Core::FIXED_LINE_OR_MOBILE_ARRAY + Core::FIXED_OR_MOBILE_ARRAY
         end
       end
       types
@@ -189,9 +188,9 @@ module Phonelib
     # * +data+  - country data
     def fixed_and_mobile_keys(data)
       if data[Core::FIXED_LINE] == data[Core::MOBILE]
-        [Core::FIXED_OR_MOBILE]
+        Core::FIXED_OR_MOBILE_ARRAY
       else
-        [Core::FIXED_LINE, Core::MOBILE]
+        Core::FIXED_LINE_OR_MOBILE_ARRAY
       end
     end
 

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -161,7 +161,7 @@ module Phonelib
     # checks if types has both :mobile and :fixed_line and replaces it with
     # :fixed_or_mobile in case both present
     def sanitize_fixed_mobile(types)
-      [:possible, :valid].each do |key|
+      Core::POSSIBLE_VALID_ARRAY.each do |key|
         if (Core::FIXED_LINE_OR_MOBILE_ARRAY - types[key]).empty?
           types[key] = types[key] - Core::FIXED_LINE_OR_MOBILE_ARRAY + Core::FIXED_OR_MOBILE_ARRAY
         end

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -119,14 +119,15 @@ module Phonelib
     # * +data+ - country data hash
     # * +country_optional+ - whether to put country code as optional group
     def full_regex_for_data(data, type, country_optional = true)
-      regex = []
-      regex << '0{2}?'
-      regex << "(#{data[Core::INTERNATIONAL_PREFIX]})?"
-      regex << "(#{data[Core::COUNTRY_CODE]})#{country_optional ? '?' : ''}"
-      regex << "(#{data[Core::NATIONAL_PREFIX_FOR_PARSING] || data[Core::NATIONAL_PREFIX]})?"
-      regex << "(#{type_regex(data[Core::TYPES][Core::GENERAL], type)})" if data[Core::TYPES]
+      regex = +"^0{2}?(#{data[Core::INTERNATIONAL_PREFIX]})?(#{data[Core::COUNTRY_CODE]})#{country_optional ? '?' : ''}(#{data[Core::NATIONAL_PREFIX_FOR_PARSING] || data[Core::NATIONAL_PREFIX]})?"
+      if data[Core::TYPES]
+        regex << "("
+        regex << type_regex(data[Core::TYPES][Core::GENERAL], type)
+        regex << ")"
+      end
+      regex << "$"
 
-      cr("^#{regex.join}$")
+      cr(regex)
     end
 
     # Returns regex for type with special types if needed

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -150,9 +150,7 @@ module Phonelib
     # * +phone+ - phone number for parsing
     # * +data+  - country data
     def phone_match_data?(phone, data, possible = false)
-      country_code = "#{data[Core::COUNTRY_CODE]}"
-      inter_prefix = "(#{data[Core::INTERNATIONAL_PREFIX]})?"
-      return unless phone.match cr("^0{2}?#{inter_prefix}#{country_code}")
+      return unless phone.match?(cr("^0{2}?(#{data[Core::INTERNATIONAL_PREFIX]})?#{data[Core::COUNTRY_CODE]}"))
 
       type = possible ? Core::POSSIBLE_PATTERN : Core::VALID_PATTERN
       phone.match full_regex_for_data(data, type, false)

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -136,11 +136,11 @@ module Phonelib
     # * +data+ - country types data for single type
     # * +type+ - possible or valid regex type needed
     def type_regex(data, type)
-      regex = [data[type]]
       if Phonelib.parse_special && data[Core::SHORT] && data[Core::SHORT][type]
-        regex << data[Core::SHORT][type]
+        "#{data[type]}|#{data[Core::SHORT][type]}"
+      else
+        data[type]
       end
-      regex.join('|')
     end
 
     # Check if phone match country data


### PR DESCRIPTION
In doing some benchmarking in an application that uses `phonelib`, I saw a few spots that may have some opportunity to improve performance. I wanted to propose changes that were relatively small but could have a larger impact on performance. My approach was to focus more on eliminating allocations where possible by moving otherwise static values into constants or consolidating string allocations. There are a couple of replacements of methods too to prefer less expensive ones (replacing `match` with `match?` and `to_s.length` with `match_length(0)`.

At least locally, the improvements look to be pretty significant:

| benchmark | master | proposed | result |
|-----|-----|-----|----|
| Known Country Memory Allocated | 14.964M | 10.162M | 32% reduction |
| Unknown Country Memory Allocated | 27.413M | 10.542M | 61% reduction |
| Known Country Parsing | 34.552 i/s | 42.581 i/s | 23% increase |
| Unknown Country Parsing |  16.249 i/s | 22.452 i/s | 38% increase |

I have some more significant changes around caching inspired by #47, and will likely open a PR with those. I also wanted to thank you for `phonelib` and its helpful structure/tooling. Having existing benchmarks to test made it really easy to work with!

### Memory usage benchmark
```
# master
$ rspec spec/phonelib_memory_bench.rb
Timing phonelib using Ruby 3.3.6
starting benchmark for 1127 numbers in 245 countries
Calculating -------------------------------------
       known country    14.964M memsize (     2.271M retained)
                       181.611k objects (     6.876k retained)
                        50.000  strings (    50.000  retained)
     unknown country    27.413M memsize (   176.799k retained)
                       363.231k objects (   573.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
       known country:   14964010 allocated
     unknown country:   27412891 allocated - 1.83x more

# proposed
Timing phonelib using Ruby 3.3.6
starting benchmark for 1127 numbers in 245 countries
Calculating -------------------------------------
       known country    10.162M memsize (     2.272M retained)
                       106.411k objects (     6.876k retained)
                        50.000  strings (    50.000  retained)
     unknown country    10.542M memsize (   176.799k retained)
                       137.597k objects (   573.000  retained)
                        50.000  strings (    50.000  retained)

Comparison:
       known country:   10161695 allocated
     unknown country:   10542221 allocated - 1.04x more
```


### Iterations per second benchmark
```
# master
Timing phonelib using Ruby 3.3.6
starting benchmark for 1127 numbers in 245 countries
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [arm64-darwin23]
Warming up --------------------------------------
       known country     3.000 i/100ms
     unknown country     1.000 i/100ms
Calculating -------------------------------------
       known country     34.552 (± 2.9%) i/s   (28.94 ms/i) -    174.000 in   5.038685s
     unknown country     16.249 (± 6.2%) i/s   (61.54 ms/i) -     82.000 in   5.054568s

Comparison:
       known country:       34.6 i/s
     unknown country:       16.2 i/s - 2.13x  slower

# proposed
Timing phonelib using Ruby 3.3.6
starting benchmark for 1127 numbers in 245 countries
ruby 3.3.6 (2024-11-05 revision 75015d4c1f) [arm64-darwin23]
Warming up --------------------------------------
       known country     4.000 i/100ms
     unknown country     2.000 i/100ms
Calculating -------------------------------------
       known country     42.581 (± 2.3%) i/s   (23.48 ms/i) -    216.000 in   5.073565s
     unknown country     22.452 (± 0.0%) i/s   (44.54 ms/i) -    114.000 in   5.079301s

Comparison:
       known country:       42.6 i/s
     unknown country:       22.5 i/s - 1.90x  slower
```