### PR TITLE
Correctly parse numbers with country codes with leading double zeros

### DIFF
--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -162,13 +162,13 @@ module Phonelib
     # * +phone+ - phone number for parsing
     # * +data+  - country data to be based on for creating e164 representation
     def convert_to_e164(phone, data)
-      match = phone.match full_regex_for_data(data, Core::VALID_PATTERN, !original_starts_with_plus?)
+      match = phone.match full_regex_for_data(data, Core::VALID_PATTERN, !original_starts_with_plus_or_double_zero?)
       case
       when match
         "#{data[Core::COUNTRY_CODE]}#{match.to_a.last}"
       when phone.match(cr("^#{data[Core::INTERNATIONAL_PREFIX]}"))
         phone.sub(cr("^#{data[Core::INTERNATIONAL_PREFIX]}"), Core::PLUS_SIGN)
-      when original_starts_with_plus? && phone.start_with?(data[Core::COUNTRY_CODE])
+      when original_starts_with_plus_or_double_zero? && phone.start_with?(data[Core::COUNTRY_CODE])
         phone
       else
         "#{data[Core::COUNTRY_CODE]}#{phone}"

--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -16,8 +16,8 @@ module Phonelib
       end
     end
 
-    def original_starts_with_plus?
-      original_s[0] == Core::PLUS_SIGN
+    def original_starts_with_plus_or_double_zero?
+      original_s[0] == Core::PLUS_SIGN || original_s[0..1] == '00'
     end
 
     # converts symbols in phone to numbers
@@ -61,7 +61,8 @@ module Phonelib
     def country_can_dp?(country)
       Phonelib.phone_data[country] &&
         Phonelib.phone_data[country][Core::DOUBLE_COUNTRY_PREFIX_FLAG] &&
-        !original_starts_with_plus? && original_s.start_with?(Phonelib.phone_data[country][Core::COUNTRY_CODE])
+        !original_starts_with_plus_or_double_zero? &&
+        original_s.start_with?(Phonelib.phone_data[country][Core::COUNTRY_CODE])
     end
 
     # changes phone to with/without double country prefix
@@ -89,7 +90,7 @@ module Phonelib
       data[Core::DOUBLE_COUNTRY_PREFIX_FLAG] &&
         phone =~ cr("^#{data[Core::COUNTRY_CODE]}") &&
         parsed && (parsed[:valid].nil? || parsed[:valid].empty?) &&
-        !original_starts_with_plus?
+        !original_starts_with_plus_or_double_zero?
     end
 
     # Returns original number passed if it's a string or empty string otherwise
@@ -103,7 +104,8 @@ module Phonelib
     #
     # * +country+ - country passed for parsing
     def country_or_default_country(country)
-      country ||= (original_starts_with_plus? ? nil : Phonelib.default_country)
+      country ||= (original_starts_with_plus_or_double_zero? ? nil : Phonelib.default_country)
+
       if country.is_a?(Array)
         country.compact.map { |e| e.to_s.upcase }
       else

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -448,11 +448,13 @@ describe Phonelib do
       phone1 = Phonelib.parse('0049032123456789', 'GB')
       phone2 = Phonelib.parse('81049032123456789', 'RU')
       phone3 = Phonelib.parse('81049032123456789', 'GB')
+      phone4 = Phonelib.parse('00962796820700','DE')
       expect(phone1.valid?).to be true
       expect(phone1.country).to eq('DE')
       expect(phone2.valid?).to be true
       expect(phone2.country).to eq('DE')
       expect(phone3.valid?).to be false
+      expect(phone4.country).to eq('JO')
     end
   end
 


### PR DESCRIPTION
Hi @daddyz , thank you for maintaining this useful library!

We came across the same issue as #231, this fixes it.

Test added as well.

[[Your reference project](https://htmlpreview.github.io/?https://github.com/google/libphonenumber/blob/master/javascript/i18n/phonenumbers/demo-compiled.html) already parses numbers with country codes with leading double zeros instead of '+' correctly.]
