### PR TITLE
Eagerload code

### DIFF
--- a/lib/phonelib.rb
+++ b/lib/phonelib.rb
@@ -3,12 +3,12 @@
 # main Phonelib module definition
 module Phonelib
   # load phonelib classes/modules
-  autoload :Core, 'phonelib/core'
-  autoload :Phone, 'phonelib/phone'
-  autoload :PhoneFormatter, 'phonelib/phone_formatter'
-  autoload :PhoneAnalyzer, 'phonelib/phone_analyzer'
-  autoload :PhoneAnalyzerHelper, 'phonelib/phone_analyzer_helper'
-  autoload :PhoneExtendedData, 'phonelib/phone_extended_data'
+  require 'phonelib/core'
+  require 'phonelib/phone_formatter'
+  require 'phonelib/phone_analyzer_helper'
+  require 'phonelib/phone_analyzer'
+  require 'phonelib/phone_extended_data'
+  require 'phonelib/phone'
 
   extend Core
 end


### PR DESCRIPTION
While I understand that `autoload` is convenient, it's not good for production performance and it cause the code to be loaded the first time the constant is referenced, in many case that means as part of the first request, and cause latency spikes on deploy.

It's better to immediately require all the code, especially since phonelib is relatively small.