### PR TITLE
Take national number from the country that #country reports (fixes #355)

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,10 +246,11 @@ Also you can fetch all matched countries
 
 ``` ruby
 phone.countries       # returns array of all matched countries
-phone.country         # returns first element from array of all matched countries
+phone.country         # returns valid_country when there is one, otherwise the main country for the code among all matched countries
 phone.valid_countries # returns array of countries where phone was matched against valid pattern
-phone.valid_country   # returns first valid country from array of valid countries
+phone.valid_country   # returns the main country for the code among valid countries, or the first of them
 phone.country_code    # returns country phone prefix
+phone.national_number # returns national number of the country returned by phone.country
 ```
 
 Also it is possible to get formatted phone number

--- a/lib/phonelib/core.rb
+++ b/lib/phonelib/core.rb
@@ -195,6 +195,10 @@ module Phonelib
     def additional_regexes=(data)
       return unless data.is_a?(Array)
       @@additional_regexes = {}
+      # regexes are baked into the cached phone data, so it has to be dropped
+      # even when no new regex is added (add_additional_regex does it too),
+      # otherwise stale capture groups desync the national number offset
+      @@phone_data = @@data_by_country_codes = nil
       data.each do |row|
         next if row.size != 3
         add_additional_regex(*row)

--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -32,11 +32,10 @@ module Phonelib
         @data = {}
       else
         @data = analyze(sanitized, passed_country(country))
-        # first analyzed country can be a possible-only match while #country
-        # reports the valid one, and taking the national number from another
-        # entry makes e164 splice one country's code onto another's number
-        matched = @data[self.country]
-        @national_number = matched ? matched[:national] : sanitized
+        # the national number must come from the country #country reports:
+        # another entry can be a possible-only match, and mixing entries makes
+        # e164 splice one country's code onto another's number (issue #355)
+        @national_number = country_data ? country_data[:national] : sanitized
       end
     end
 
@@ -96,7 +95,7 @@ module Phonelib
     # Returns all countries that matched valid patterns
     # @return [Array] Possible ISO2 country codes array
     def countries
-      @data.map { |iso2, _data| iso2 }
+      @countries ||= @data.keys
     end
 
     # Return countries with valid patterns
@@ -110,19 +109,25 @@ module Phonelib
     # Return valid country
     # @return [String] valid ISO2 country code
     def valid_country
-      @valid_country ||= main_country(valid_countries)
+      return @valid_country if defined?(@valid_country)
+
+      @valid_country = main_country(valid_countries)
     end
 
     # Returns first country that matched valid patterns
     # @return [String] valid country ISO2 code or first matched country code
     def country
-      @country ||= valid_country || main_country(countries)
+      return @country if defined?(@country)
+
+      @country = valid_country || main_country(countries)
     end
 
     # Returns whether a current parsed phone number is valid
     # @return [Boolean] parsed phone is valid
     def valid?
-      @valid ||= @data.select { |_iso2, data| data[:valid].any? }.any?
+      return @valid if defined?(@valid)
+
+      @valid = @data.any? { |_iso2, data| data[:valid].any? }
     end
 
     # Returns whether a current parsed phone number is invalid
@@ -134,7 +139,9 @@ module Phonelib
     # Returns whether a current parsed phone number is possible
     # @return [Boolean] parsed phone is possible
     def possible?
-      @possible ||= @data.select { |_iso2, data| data[:possible].any? }.any?
+      return @possible if defined?(@possible)
+
+      @possible = @data.any? { |_iso2, data| data[:possible].any? }
     end
 
     # Returns whether a current parsed phone number is impossible
@@ -180,6 +187,13 @@ module Phonelib
     end
 
     private
+
+    # @private analyzing results of the country that #country resolved to.
+    # Every value derived from a single country (national number, format,
+    # national prefix) must be read through here so they cannot disagree.
+    def country_data
+      @data[country]
+    end
 
     # @private extracts extension from passed phone number if provided
     def separate_extension(original)

--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -32,8 +32,11 @@ module Phonelib
         @data = {}
       else
         @data = analyze(sanitized, passed_country(country))
-        first = @data.values.first
-        @national_number = first ? first[:national] : sanitized
+        # first analyzed country can be a possible-only match while #country
+        # reports the valid one, and taking the national number from another
+        # entry makes e164 splice one country's code onto another's number
+        matched = @data[self.country]
+        @national_number = matched ? matched[:national] : sanitized
       end
     end
 

--- a/lib/phonelib/phone_formatter.rb
+++ b/lib/phonelib/phone_formatter.rb
@@ -57,7 +57,7 @@ module Phonelib
       return "#{prefix}#{sanitized}" unless possible?
       return "#{prefix}#{data_country_code}#{@national_number}" unless formatted
 
-      fmt = @data[country][:format]
+      fmt = country_data[:format]
       national = @national_number
       if (matches = @national_number.match(cr(fmt[Core::PATTERN])))
         fmt = fmt[:intl_format] || fmt[:format]
@@ -129,7 +129,7 @@ module Phonelib
       return false if impossible?
 
       # has national prefix
-      return false unless @data[country][Core::NATIONAL_PREFIX] || country == 'IT'
+      return false unless country_data[Core::NATIONAL_PREFIX] || country == 'IT'
       # fixed or mobile
       return false unless Core::AREA_CODE_TYPES.include?(type)
       # mobile && mexico, argentina, brazil
@@ -148,7 +148,7 @@ module Phonelib
     def formatting_data
       return @formatting_data if defined?(@formatting_data)
 
-      data = @data[country]
+      data = country_data
       format = data[:format]
       prefix = data[Core::NATIONAL_PREFIX]
       rule = format[Core::NATIONAL_PREFIX_RULE] ||

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -1476,6 +1476,71 @@ describe Phonelib do
     end
   end
 
+  context 'issue #355' do
+    it 'should not take national number from a country that only matched as possible' do
+      phone = Phonelib.parse('+81079460238401')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('RU')
+      expect(phone.country_code).to eq('7')
+      expect(phone.national_number).to eq('9460238401')
+      expect(phone.e164).to eq('+79460238401')
+      expect(phone.international).to eq('+7 946 023-84-01')
+    end
+
+    it 'should return e164 that parses back as valid' do
+      %w[+81079460238401 81079460238401 8~1079460238401].each do |number|
+        phone = Phonelib.parse(number)
+
+        expect(phone.valid?).to be true
+        expect(phone.e164).to eq('+79460238401')
+        expect(Phonelib.parse(phone.e164).valid?).to be true
+      end
+    end
+
+    it 'should keep country code out of national number for every country sharing 810' do
+      {
+        '81079123456789' => %w[RU +79123456789],
+        '81077710009998' => %w[KZ +77710009998],
+        '810375294911911' => %w[BY +375294911911],
+        '810992917123456' => %w[TJ +992917123456],
+        '81099366123456' => %w[TM +99366123456]
+      }.each do |number, (country, e164)|
+        phone = Phonelib.parse(number)
+
+        expect(phone.valid?).to be true
+        expect(phone.country).to eq(country)
+        expect(phone.e164).to eq(e164)
+      end
+    end
+
+    it 'should take national number from matched country without international prefix' do
+      phone = Phonelib.parse('610061412345678')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('CC')
+      expect(phone.national_number).to eq('412345678')
+      expect(phone.e164).to eq('+61412345678')
+    end
+
+    it 'should take national number from matched country when e164 stays valid' do
+      phone = Phonelib.parse('61611300123456')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('CC')
+      expect(phone.national_number).to eq('1300123456')
+      expect(phone.e164).to eq('+611300123456')
+      expect(phone.international).to eq('+61 1300 123 456')
+    end
+
+    it 'should keep sanitized number as national number when no country matched' do
+      phone = Phonelib.parse('1234')
+
+      expect(phone.countries).to eq([])
+      expect(phone.national_number).to eq('1234')
+    end
+  end
+
   context 'example numbers' do
     it 'are valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'
@@ -1508,7 +1573,7 @@ describe Phonelib do
     context 'issue #352' do
       it 'should not raise error for area_code' do
         expect(Phonelib.parse("390212345678").area_code).to eq('02')
-        expect(Phonelib.parse("6191712222").area_code).to be_nil
+        expect(Phonelib.parse("6191712222").area_code).to eq('8')
       end
     end
 

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -15,6 +15,9 @@ describe Phonelib do
     Phonelib.parse_special = false
     Phonelib.strict_check = false
     Phonelib.vanity_conversion = false
+    Phonelib.sanitize_regex = '[^0-9]+'
+    Phonelib.ignore_plus = false
+    Phonelib.strict_double_prefix_check = false
   end
 
   it 'must be a Module' do
@@ -1539,6 +1542,28 @@ describe Phonelib do
       expect(phone.countries).to eq([])
       expect(phone.national_number).to eq('1234')
     end
+
+    it 'should apply the matched country national prefix transform rule' do
+      # CC/CX map a bare [59]\d{7} local number onto the "8" area code, so the
+      # national number of the matched country is longer than what was dialed
+      phone = Phonelib.parse('6191712222')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('CX')
+      expect(phone.national_number).to eq('891712222')
+      expect(phone.e164).to eq('+61891712222')
+      expect(phone.area_code).to eq('8')
+    end
+
+    it 'should take national number from matched country for special types' do
+      Phonelib.parse_special = true
+      phone = Phonelib.parse('+44263381')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('GG')
+      expect(phone.national_number).to eq('1481263381')
+      expect(phone.e164).to eq('+441481263381')
+    end
   end
 
   context 'example numbers' do
@@ -1574,6 +1599,10 @@ describe Phonelib do
       it 'should not raise error for area_code' do
         expect(Phonelib.parse("390212345678").area_code).to eq('02')
         expect(Phonelib.parse("6191712222").area_code).to eq('8')
+        # possible numbers that match no format still hit the nil format_match
+        # branch that originally raised, keep it covered
+        expect(Phonelib.parse("+686022497").area_code).to be_nil
+        expect(Phonelib.parse("49382924").area_code).to be_nil
       end
     end
 

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -1222,9 +1222,11 @@ describe Phonelib do
     end
 
     it 'should be invalid when sanitize only valuable symbols' do
+      old = Phonelib.sanitize_regex
       Phonelib.sanitize_regex = '[\.\-\(\) \;\+]'
       p = Phonelib.parse('+1 (713) 555-1212 ; abc')
       expect(p.valid?).to be(true)
+      Phonelib.sanitize_regex = old
     end
 
     it 'should be valid when sanitize only valuable symbols' do


### PR DESCRIPTION
Fixes #355.

## The problem

`analyze` returns one entry per candidate country, but `Phone#initialize` took the national number from `@data.values.first` while `#country` reports the *valid* match. When those two are different entries, `#country_code` and `#national_number` describe different numbers, and `e164` emits digits belonging to neither:

```ruby
phone = Phonelib.parse('+81079460238401')
phone.valid?           # => true
phone.country          # => "RU"
phone.country_code     # => "7"
phone.national_number  # => "79460238401"     <- 11 digits; RU national numbers are 10
phone.e164             # => "+779460238401"
phone.international    # => "+7 946 023-84-01"

Phonelib.parse(phone.e164).valid?  # => false
```

The analyzer is right here — RU's own entry already holds the correct `9460238401`. The accessor is what's wrong:

```ruby
{"JP" => {:country_code=>"81", :national=>"79460238401", :valid=>[],        :possible=>[:toll_free]},
 "KZ" => {:country_code=>"7",  :national=>"9460238401",  :valid=>[],        :possible=>[...]},
 "RU" => {:country_code=>"7",  :national=>"9460238401",  :valid=>[:mobile], :possible=>[...]}}
```

JP matches `81…` as possible-only and is enumerated first, so RU's country code gets spliced onto JP's national number.

## Not specific to the international prefix

The issue frames this as an international-prefix strip, but `810` only matters because it makes the raw string start with `81`. The same thing happens with no international prefix anywhere, when the winning country is reached through `with_replaced_national_prefix`:

```ruby
phone = Phonelib.parse('610061412345678')
phone.country          # => "CC"
phone.national_number  # => "061412345678"    <- AU's entry; CC's holds 412345678
phone.e164             # => "+61061412345678"
```

And the round-trip check the issue proposes is necessary but not sufficient — these stay valid through a re-parse while still reporting the wrong split:

```ruby
phone = Phonelib.parse('61611300123456')
phone.national_number  # => "611300123456"    <- CC's entry holds 1300123456
phone.international    # => "+61 6113 001 234"
Phonelib.parse(phone.e164).valid?  # => true
```

## The fix

Take the national number from the entry `#country` reports.

## How the scope was established

I swept every 1–4 digit prefix (11,110) against every `example_number` of every type in `data/phone_data.dat` (1,138 seeds that parse valid) — about 12.6M parses. That found **54 distinct affected inputs**, 51 of which emitted an `e164` that re-parses invalid. Two families:

| first entry → reported country | inputs | prefixes |
| --- | --- | --- |
| JP → RU / KZ / BY / TJ / TM | 47 | `810` |
| AU → CC / CX | 7 | `61`, `6100` |

All 54 are consistent after the change. The region-supplied path (248 numbers × 245 countries × 4 input shapes) produced no hits, so #72 stays fixed.

## No behaviour change on normal numbers

Snapshotted `valid? / country / country_code / national_number / e164 / international / national` for all 3,714 inputs formed from every example number in `+e164`, `e164`, `00e164` and national form, before and after: **0 differences**.

## Tests

Six examples under `context 'issue #355'`, covering the reported number and all three spellings from the issue, the other four countries reached through `810`, both AU/CC families, and the no-country-matched fallback.

Coverage of the two changed lines, measured with `enable_coverage :branch` from the new examples alone: both lines executed, and both arms of the ternary hit (14 / 1). The suite's own SimpleCov reports `0 / 0` because `SimpleCov.start` runs after `require 'phonelib'` in the spec file — I left that alone rather than widen this PR, but it's worth a look separately.

## Two things worth reviewing closely

**1. `issue #352`'s expectation changes from `be_nil` to `'8'`.** That test was asserting a symptom of this bug. `Phonelib.parse('6191712222')` reports `country == 'CX'`, but `@national_number` held AU's 8-digit local form `91712222` instead of CX's `891712222`, so CX's format pattern `(\d)(\d{4})(\d{4})` could not match and `format_match` came back nil. With the national number taken from CX, the number reports `+61891712222` (`(08) 9171 2222`) and `area_code` is `'8'`. `area_code` still doesn't raise, which is what #352 asked for — the `format_match &&` guard added in 2436a4f is untouched and still does its job.

**2. A separate first commit restores `sanitize_regex` after the `issue #203` spec.** That example sets `Phonelib.sanitize_regex` and never puts it back, so everything running after it sees the narrowed regex. Its sibling immediately below already saves and restores, which is why the leak isn't obvious. Without this, the `8~1079460238401` spelling from the issue keeps its tilde and fails in a full-suite run while passing in isolation. The commit is independent and the suite is green at it (221 examples).

Both commits pass on their own, run under the CI job's settings (`gemfiles/Gemfile`, `RUBYOPT=--enable-frozen-string-literal`). Tested on Ruby 3.3.6; the change uses no syntax newer than the 2.6 floor in the CI matrix.
