### PR TITLE
Look past leading characters when detecting a leading plus (fixes #356)

### DIFF
--- a/lib/phonelib/phone_analyzer_helper.rb
+++ b/lib/phonelib/phone_analyzer_helper.rb
@@ -17,7 +17,7 @@ module Phonelib
     end
 
     def original_starts_with_plus_or_double_zero?
-      original_s[0] == Core::PLUS_SIGN || original_s[0..1] == '00'
+      significant_original_s[0] == Core::PLUS_SIGN || significant_original_s[0..1] == '00'
     end
 
     # converts symbols in phone to numbers
@@ -37,8 +37,9 @@ module Phonelib
     # defines if to validate against single country or not
     def passed_country(country)
       code = country_prefix(country)
-      if !Phonelib.ignore_plus && Core::PLUS_SIGN == @original[0] && code && !sanitized.start_with?(code)
-        # in case number passed with + but it doesn't start with passed
+      if !Phonelib.ignore_plus && original_starts_with_plus_or_double_zero? && code &&
+         !sanitized.delete_prefix('00').start_with?(code)
+        # in case number passed with + or 00 but it doesn't start with passed
         # country prefix
         country = nil
       end
@@ -96,6 +97,15 @@ module Phonelib
     # Returns original number passed if it's a string or empty string otherwise
     def original_s
       @original_s ||= @original.is_a?(String) ? @original : ''
+    end
+
+    # Returns original number without the leading characters that libphonenumber
+    # drops in extractPossibleNumber, so a plus or 00 written behind punctuation
+    # like "(+501) 623-6848" is still recognized as leading. Vanity conversion
+    # runs first, the same way +sanitized+ applies it, so leading letters that
+    # convert to significant digits are not stripped as junk.
+    def significant_original_s
+      @significant_original_s ||= vanity_converted(original_s).sub(cr('\A[^0-9+]+'), '')
     end
 
     # Get country that was provided or default country in needable format

--- a/spec/phonelib_spec.rb
+++ b/spec/phonelib_spec.rb
@@ -1474,6 +1474,67 @@ describe Phonelib do
     end
   end
 
+  context 'issue #356' do
+    it 'should respect plus sign written behind parenthesis when country passed' do
+      phone = Phonelib.parse('(+501) 623-6848', 'US')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('BZ')
+      expect(phone.e164).to eq('+5016236848')
+    end
+
+    it 'should respect plus sign written behind space when country passed' do
+      phone = Phonelib.parse(' +501 623-6848', 'US')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('BZ')
+      expect(phone.e164).to eq('+5016236848')
+    end
+
+    it 'should respect plus sign of passed country written behind parenthesis' do
+      phone = Phonelib.parse('(+1) 501 623-6848', 'BZ')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('US')
+      expect(phone.e164).to eq('+15016236848')
+    end
+
+    it 'should not use default country for plus sign behind parenthesis' do
+      Phonelib.default_country = 'US'
+      phone = Phonelib.parse('(+32) 12 34 56 78')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('BE')
+      expect(phone.e164).to eq('+3212345678')
+    end
+
+    it 'should not use default country for double zero behind parenthesis' do
+      Phonelib.default_country = 'US'
+      phone = Phonelib.parse('(0032) 12 34 56 78')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('BE')
+      expect(phone.e164).to eq('+3212345678')
+    end
+
+    it 'should use passed country for national number behind parenthesis' do
+      phone = Phonelib.parse('( 212 ) 555-1234', 'US')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('US')
+      expect(phone.e164).to eq('+12125551234')
+    end
+
+    it 'should not treat plus sign following a digit as leading' do
+      Phonelib.default_country = 'US'
+      phone = Phonelib.parse('1+3212345678')
+
+      expect(phone.valid?).to be true
+      expect(phone.country).to eq('US')
+      expect(phone.e164).to eq('+13212345678')
+    end
+  end
+
   context 'example numbers' do
     it 'are valid' do
       data_file = File.dirname(__FILE__) + '/../data/phone_data.dat'


### PR DESCRIPTION
Fixes #356.

## The bug

A leading plus was detected as `original_s[0]`, so a parenthesis, space, tab, dot or dash in front of it hid it and the passed or default country won over the country code the number carries:

```ruby
Phonelib.parse('+501 623-6848', 'US').country    # => "BZ"   +5016236848
Phonelib.parse('(+501) 623-6848', 'US').country  # => "US"   +15016236848  (Arkansas)
```

`(+34) 954 28 28 80` and `(+886)-02-8785-1177` are ordinary spreadsheet shapes.

## The fix

libphonenumber drops the leading characters up to the first digit or plus in `extractPossibleNumber` (`VALID_START_CHAR = "[" + PLUS_CHARS + DIGITS + "]"`), so the parenthesised form is expected to parse like the bare one. `significant_original_s` does that strip once per instance, and the plus checks read it instead of the raw original.

`passed_country` needed the same treatment, which is why the one-method patch suggested in the issue isn't enough on its own. It compares `Core::PLUS_SIGN` with `@original[0]` to decide whether a passed country that contradicts the number's own code should be dropped; with only `original_starts_with_plus_or_double_zero?` fixed, `'(+501) 623-6848'` still parses as US, because the country survives and `convert_to_e164` falls through to prefixing `1` to all ten digits.

Two details, both needed to avoid trading the reported bug for a new one:

- `passed_country` now tests `00` as well, and compares against `sanitized` without that prefix. Otherwise a passed country contradicting an explicit `00` is never released while `convert_to_e164` simultaneously makes the country code mandatory, and `('(0032) 12345678', 'US')` resolves to nothing with a malformed `+003212345678`.
- the strip runs on `vanity_converted(original_s)` rather than the raw original, so under `vanity_conversion` leading letters that become significant digits are not discarded as junk. Otherwise `('W+1 800 555 1234', 'US')` reads the plus as leading and returns IN `+918005551234`.

Only characters *before* the first digit or plus are dropped, so a plus that follows a digit is still not a leading plus — `'1+3212345678'` keeps using the default country, as it does today.

## Behaviour verified across the whole data file

Every `example_number` in `phone_data.dat` across 14 leading forms — `+cc`, `(+cc)`, ` +cc`, `-+cc`, `.+cc`, letter-prefixed, `00cc`, `(00cc)`, ` 00cc`, bare national, ` national`, `(national)` and ` + national` — against a passed country (own, `US`, `GB`, none) and against a `default_country` (`US`, `DE`). 94,500 parses per revision, compared before and after:

| | changed | invalid → valid | valid → invalid |
| --- | --- | --- | --- |
| master → this PR | 27,517 | 15,281 | 2,229 |

The invariant the issue asks for holds exactly. A decorated plus versus the bare `+` form, comparing `valid?`, `country` and `e164`:

| revision | disagreeing pairs |
| --- | --- |
| master | 18,534 / 40,500 |
| this PR | **0 / 40,500** |

## Behaviour change worth a CHANGELOG note

The 2,229 valid → invalid rows are an explicit `+` or `00` in front of a *national* number under a contradicting passed country. Master's handling of these was incoherent, because the marker only counted at index 0:

```ruby
Phonelib.parse('+212 555 1234',  'US')  # master: invalid
Phonelib.parse(' +212 555 1234', 'US')  # master: valid, US, +12125551234   <- one space flips it
```

`+212` is Morocco's country code and `5551234` is too short for Morocco, so honouring the explicit `+` and rejecting is the consistent answer, and all spacings now agree.

A separate check of the 8 `double_prefix` countries shows the same shape for `00` in front of a doubled country code — `(' 00494930123456', 'DE')` goes valid → invalid, matching the unspaced `'00494930123456'` that master already rejected. Worth calling out on release, since it is a real strictness increase for whitespace-padded input such as CSV and form data.

## Tests

7 examples under `context 'issue #356'`, covering: the plus behind a parenthesis and behind a space with a country passed, a passed country overridden by a different `+1`, `default_country` losing to both `(+32)` and `(0032)`, a parenthesised *national* number still using the passed country, and a plus after a digit not counting as leading.

Full suite green on 3.4.7: 228 examples, 0 failures.

`spec/phonelib_ips_bench.rb` shows no measurable difference — three runs gave 44.8 / 40.8 / 43.7 i/s on master against 42.5 / 44.3 / 44.5 here for `known country`, against a run-to-run spread of around 10% on this machine. The added work is one cached-regex `sub` per instance, memoised.

## Two unrelated things noticed while testing

Both are pre-existing, reproducible on master, and deliberately left alone here.

`PhoneFormatter#international` returns `"#{prefix}#{sanitized}"` unless `possible?`, and `sanitized` keeps a `00` international prefix, so not-possible numbers get a malformed E.164. Independent of this change — no country passed, and byte-identical before and after:

```ruby
Phonelib.parse('0099999999999').e164  # => "+0099999999999"
```

And `significant_original_s` uses `[^0-9+]`, which is ASCII-only, so the fullwidth plus is stripped as junk and disagrees with its ASCII twin. Not a regression, since the old index-0 check missed it too:

```ruby
Phonelib.parse('＋501 623-6848', 'US').country  # => "US"
Phonelib.parse('+501 623-6848', 'US').country   # => "BZ"
```

Independent of #357 — that one touches `phone.rb`, this one `phone_analyzer_helper.rb`, and they don't overlap in either direction.
