### PR TITLE
Skip the national prefix re-parse when the phone is unchanged

### DIFF
--- a/lib/phonelib/phone_analyzer.rb
+++ b/lib/phonelib/phone_analyzer.rb
@@ -139,7 +139,9 @@ module Phonelib
         key = data[:id]
         parsed = parse_single_country(phone, data)
         unless parsed && parsed[key] && parsed[key][:valid].size > 0
-          replaced_parsed = parse_single_country(with_replaced_national_prefix(phone, data), data)
+          replaced = with_replaced_national_prefix(phone, data)
+          # re-parsing an unchanged phone cannot change the result
+          replaced_parsed = parse_single_country(replaced, data) unless replaced == phone
           parsed = replaced_parsed unless replaced_parsed.nil?
         end
         if (!Phonelib.strict_double_prefix_check || key == country) && double_prefix_allowed?(data, phone, parsed && parsed[key])


### PR DESCRIPTION
`detect_and_parse` re-parses every candidate country through `with_replaced_national_prefix`, but that method returns the phone unchanged for most of them — only 32 of 254 countries have a `national_prefix_transform_rule`. Parsing the same string twice cannot give a different result, so this skips the second call.

No behaviour change. `spec/phonelib_ips_bench.rb`:

| | before | after |
| --- | --- | --- |
| known country | 46.2 i/s | 46.6 i/s |
| unknown country | 27.2 i/s | 38.2 i/s |

`spec/phonelib_memory_bench.rb`, unknown country: 9.74M → 7.33M allocated.

237 examples pass. I did not add a test: the branch is already covered by the issue #355, #325 and #352 specs, which fail if the re-parse is dropped entirely.
