### PR TITLE
Deduplicate extended phone data to save ~41MB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Upcoming Changes (unreleased)
+- Deduplicate extended data to reduce runtime memory usage by ~41MB
 
 ## 0.6.55 - 10 January 2022
 - updated data

--- a/lib/phonelib/data_importer_helper.rb
+++ b/lib/phonelib/data_importer_helper.rb
@@ -22,7 +22,7 @@ module Phonelib
     # method saves extended data file
     def save_extended_data_file
       extended = {
-        Phonelib::Core::EXT_PREFIXES => @prefixes,
+        Phonelib::Core::EXT_PREFIXES => intern_hashes(@prefixes),
         Phonelib::Core::EXT_GEO_NAMES => @geo_names,
         Phonelib::Core::EXT_COUNTRY_NAMES => @countries,
         Phonelib::Core::EXT_TIMEZONES => @timezones,
@@ -32,6 +32,14 @@ module Phonelib
         Marshal.dump(extended, f)
       end
       puts 'DATA SAVED'
+    end
+
+    def intern_hashes(hash, table = {})
+      canonical = {}
+      hash.each do |k, v|
+        canonical[k] = v.is_a?(Hash) ? intern_hashes(v, table) : v
+      end
+      table[canonical] ||= canonical
     end
 
     # method updates prefixes hash recursively


### PR DESCRIPTION
While profiling one of our applicatin's memory usage, we found that Phonelib's extended data is a large chunk of it (~63 MB). And additionally, a lot of that memory is for hashes that have the exact same content.

This commit implements Hash interning for the extended_data file so that exact duplicate Hashes now only exist once. Since this file is `@private` and `.freeze` (at least at the top level), this shouldn't be a breaking change. However, to be safer, `freeze: true` could be added to `Marshal.load` so that the structure is deep frozen (but this requires Ruby 3.1+).

With extended data deduplicated, it is now only ~22 MB at runtime, for a ~41 MB savings.

(I did not actually regenerate the extended data file since I'd be committing a binary blob, I'll leave that up to a maintainer)