### PR TITLE
Load the Railtie only when Rails::Railtie is available

### DIFF
--- a/lib/phonelib.rb
+++ b/lib/phonelib.rb
@@ -15,12 +15,6 @@ end
 
 if defined?(ActiveModel) || defined?(Rails)
   autoload :PhoneValidator, 'validators/phone_validator'
-
-  if defined?(Rails)
-    class Phonelib::Railtie < Rails::Railtie
-      initializer 'phonelib' do |app|
-        app.config.eager_load_namespaces << Phonelib
-      end
-    end
-  end
 end
+
+require 'phonelib/railtie' if defined?(Rails::Railtie)

--- a/lib/phonelib/railtie.rb
+++ b/lib/phonelib/railtie.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Phonelib
+  class Railtie < Rails::Railtie
+    initializer 'phonelib' do |app|
+      app.config.eager_load_namespaces << Phonelib
+    end
+  end
+end

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -4,10 +4,23 @@ require 'open3'
 require 'rbconfig'
 
 describe 'Rails integration' do
+  def unbundled_environment
+    environment = {
+      'RUBYLIB' => nil,
+      'RUBYOPT' => nil,
+      'RUBYGEMS_GEMDEPS' => nil
+    }
+    ENV.each_key do |name|
+      environment[name] = nil if name.start_with?('BUNDLE_')
+    end
+    environment
+  end
+
   def run_phonelib_script(program)
     lib_path = File.expand_path('../lib', File.dirname(__FILE__))
 
     Open3.capture3(
+      unbundled_environment,
       RbConfig.ruby,
       "-I#{lib_path}",
       '-e',

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -22,6 +22,7 @@ describe 'Rails integration' do
     Open3.capture3(
       unbundled_environment,
       RbConfig.ruby,
+      '--disable-gems',
       "-I#{lib_path}",
       '-e',
       program

--- a/spec/rails_integration_spec.rb
+++ b/spec/rails_integration_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'open3'
+require 'rbconfig'
+
+describe 'Rails integration' do
+  def run_phonelib_script(program)
+    lib_path = File.expand_path('../lib', File.dirname(__FILE__))
+
+    Open3.capture3(
+      RbConfig.ruby,
+      "-I#{lib_path}",
+      '-e',
+      program
+    )
+  end
+
+  def expect_phonelib_script_to_succeed(program)
+    _stdout, stderr, status = run_phonelib_script(program)
+
+    expect(status.success?).to eq(true), stderr
+  end
+
+  it 'loads when Rails is defined before Rails::Railtie is available' do
+    program = <<-RUBY
+      module Rails
+      end
+
+      require 'phonelib'
+
+      abort 'Phonelib loaded optional Rails components' if defined?(Rails::Railtie)
+    RUBY
+
+    expect_phonelib_script_to_succeed(program)
+  end
+
+  it 'registers eager loading when Rails::Railtie is available' do
+    program = <<-RUBY
+      module Rails
+        class Railtie
+          class << self
+            attr_reader :initializer_name, :initializer_block
+
+            def initializer(name, &block)
+              @initializer_name = name
+              @initializer_block = block
+            end
+          end
+        end
+      end
+
+      require 'phonelib'
+
+      abort 'Phonelib::Railtie was not registered' unless Phonelib::Railtie < Rails::Railtie
+      abort 'Phonelib initializer was not registered' unless Phonelib::Railtie.initializer_name == 'phonelib'
+
+      config = Struct.new(:eager_load_namespaces).new([])
+      app = Struct.new(:config).new(config)
+      Phonelib::Railtie.initializer_block.call(app)
+
+      abort 'Phonelib was not added to eager load namespaces' unless config.eager_load_namespaces == [Phonelib]
+    RUBY
+
+    expect_phonelib_script_to_succeed(program)
+  end
+end


### PR DESCRIPTION
Fixes #300.

During Bundler preload, `Rails` can be defined before `Rails::Railtie`, causing Phonelib to raise `NameError` while loading.

Load the Rails integration only when `Rails::Railtie` is available and move it to the conventional `phonelib/railtie` file. This keeps Rails optional and preserves the existing eager-load initializer during normal Rails boot.

Tests cover both partial Rails loading and Railtie registration.
