### PR TITLE
Add international-prefix and E.164 validation options (fixes #195)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Upcoming Changes (unreleased)
 - Deduplicate extended data to reduce runtime memory usage by ~41MB
+- Add validator options for requiring an international prefix or canonical E.164 input
 
 ## 0.6.55 - 10 January 2022
 - updated data

--- a/README.md
+++ b/README.md
@@ -154,6 +154,10 @@ if mixed with <tt>possible</tt> will check if number is possible for specified c
 
 <tt>extensions: false</tt> - set to perform check for phone extension to be blank
 
+<tt>require_international_prefix: true</tt> - requires the original value to use <tt>+</tt> or <tt>00</tt> as its explicit international marker. The marker may follow leading formatting characters recognized by the parser. This option does not change the parser or the formatted output.
+
+<tt>format: :e164</tt> - requires the original value to match Phonelib's canonical <tt>+</tt>-prefixed E.164 representation: 2 to 15 total ASCII digits, beginning with 1-9, with no spaces, punctuation, or extension. Unsupported formats raise an <tt>ArgumentError</tt> when the validator is configured.
+
 ### Basic usage
 
 To check if phone number is valid simply run:

--- a/lib/phonelib/phone.rb
+++ b/lib/phonelib/phone.rb
@@ -62,6 +62,13 @@ module Phonelib
               '')
     end
 
+    # Returns whether the original input begins with an explicit + or 00
+    # international prefix after parser-recognized leading formatting.
+    # @return [Boolean] original input has an explicit international prefix
+    def explicit_international_prefix?
+      !!original_starts_with_plus_or_double_zero?
+    end
+
     # Returns all phone types that matched valid patterns
     # @return [Array] all valid phone types
     def types

--- a/lib/validators/phone_validator.rb
+++ b/lib/validators/phone_validator.rb
@@ -53,16 +53,40 @@
 #     validates :number, phone: { extensions: false }
 #   end
 #
+# Validates that the original value includes an explicit international prefix.
+# Both + and 00 prefixes are accepted.
+#
+#   class Phone < ActiveRecord::Base
+#     validates :number, phone: { require_international_prefix: true }
+#   end
+#
+# Validates that the original value uses canonical E.164 input format.
+#
+#   class Phone < ActiveRecord::Base
+#     validates :number, phone: { format: :e164 }
+#   end
+#
 class PhoneValidator < ActiveModel::EachValidator
+  E164_PATTERN = /\A\+[1-9][0-9]{1,14}\z/
+  SUPPORTED_FORMATS = [:e164, 'e164'].freeze
+
   # Include all core methods
   include Phonelib::Core
+
+  def check_validity!
+    return unless options.has_key?(:format)
+    return if SUPPORTED_FORMATS.include?(options[:format])
+
+    raise ArgumentError, "Unsupported phone format: #{options[:format]}"
+  end
 
   # Validation method
   def validate_each(record, attribute, value)
     return if options[:allow_blank] && value.blank?
 
     @phone = parse(value, specified_country(record))
-    valid = phone_valid? && valid_types? && valid_country? && valid_extensions?
+    valid = phone_valid? && valid_types? && valid_country? && valid_extensions? &&
+            valid_international_prefix? && valid_input_format?(value)
 
     record.errors.add(attribute, message, **options) unless valid
   end
@@ -90,6 +114,18 @@ class PhoneValidator < ActiveModel::EachValidator
   def valid_extensions?
     return true if !options.has_key?(:extensions) || options[:extensions]
     @phone.extension.empty?
+  end
+
+  def valid_international_prefix?
+    return true unless options[:require_international_prefix]
+
+    @phone.explicit_international_prefix?
+  end
+
+  def valid_input_format?(value)
+    return true unless options[:format]
+
+    SUPPORTED_FORMATS.include?(options[:format]) && value.is_a?(String) && value.match?(E164_PATTERN)
   end
 
   def specified_country(record)

--- a/spec/phone_validator_spec.rb
+++ b/spec/phone_validator_spec.rb
@@ -1,0 +1,172 @@
+# frozen_string_literal: true
+
+begin
+  require 'active_model'
+rescue LoadError
+  # PhoneValidator is only available when ActiveModel is installed.
+end
+
+require 'phonelib'
+
+if defined?(ActiveModel)
+  describe PhoneValidator do
+    before(:all) do
+      Phonelib.override_phone_data = 'spec/dummy/lib/override_phone_data.dat'
+    end
+
+    let(:model_class) do
+      Class.new do
+        include ActiveModel::Validations
+
+        attr_accessor :phone_number
+
+        validates :phone_number, phone: { require_international_prefix: true }
+      end
+    end
+
+    let(:record) { model_class.new }
+
+    context 'without an input constraint' do
+      let(:model_class) do
+        Class.new do
+          include ActiveModel::Validations
+
+          attr_accessor :phone_number
+
+          validates :phone_number, phone: true
+        end
+      end
+
+      it 'keeps accepting a valid phone number without an international prefix' do
+        record.phone_number = '41442511234'
+
+        expect(record).to be_valid
+      end
+    end
+
+    context 'when an international prefix is required' do
+      it 'accepts a valid phone number with an international prefix' do
+        record.phone_number = '+41442511234'
+
+        expect(record).to be_valid
+      end
+
+      it 'accepts double zero as an international prefix' do
+        record.phone_number = '0041442511234'
+
+        expect(record).to be_valid
+      end
+
+      it 'accepts an international prefix behind leading formatting characters' do
+        record.phone_number = '(+41) 44 251 12 34'
+
+        expect(record).to be_valid
+      end
+
+      it 'rejects a valid phone number without an international prefix' do
+        record.phone_number = '41442511234'
+
+        expect(record).not_to be_valid
+      end
+
+      context 'with vanity conversion enabled' do
+        before do
+          Phonelib.vanity_conversion = true
+        end
+
+        after do
+          Phonelib.vanity_conversion = false
+        end
+
+        it 'rejects a plus sign following a vanity digit' do
+          record.phone_number = 'G+376712345'
+
+          expect(record).not_to be_valid
+        end
+
+        it 'rejects double zero following a vanity digit' do
+          record.phone_number = 'T0024762889'
+
+          expect(record).not_to be_valid
+        end
+      end
+    end
+
+    context 'when E.164 format is required' do
+      let(:input_format) { :e164 }
+
+      let(:model_class) do
+        format = input_format
+
+        Class.new do
+          include ActiveModel::Validations
+
+          attr_accessor :phone_number
+
+          validates :phone_number, phone: { format: format }
+        end
+      end
+
+      it 'accepts a valid phone number in canonical E.164 format' do
+        record.phone_number = '+41442511234'
+
+        expect(record).to be_valid
+      end
+
+      it 'accepts a valid phone number with the E.164 maximum of 15 digits' do
+        record.phone_number = '+498001234567890'
+
+        expect(record).to be_valid
+      end
+
+      it 'rejects an internationally formatted phone number that is not canonical E.164' do
+        record.phone_number = '+41 44 251 12 34'
+
+        expect(record).not_to be_valid
+      end
+
+      it 'rejects a phone number with a double-zero prefix' do
+        record.phone_number = '0041442511234'
+
+        expect(record).not_to be_valid
+      end
+
+      {
+        'a single digit' => '+1',
+        'an otherwise canonical but invalid two-digit phone number' => '+12',
+        'more than 15 digits' => '+4980012345678901',
+        'a leading zero' => '+041442511234',
+        'an extension' => '+41442511234;123',
+        'a non-string input' => 41442511234
+      }.each do |description, value|
+        it "rejects #{description}" do
+          record.phone_number = value
+
+          expect(record).not_to be_valid
+        end
+      end
+
+      context 'when configured with a string format name' do
+        let(:input_format) { 'e164' }
+
+        it 'accepts a valid canonical value' do
+          record.phone_number = '+41442511234'
+
+          expect(record).to be_valid
+        end
+      end
+    end
+
+    it 'rejects unsupported input formats when the validator is configured' do
+      expect {
+        Class.new do
+          include ActiveModel::Validations
+
+          attr_accessor :phone_number
+
+          validates :phone_number, phone: { format: :national }
+        end
+      }.to raise_error(ArgumentError, 'Unsupported phone format: national')
+    end
+  end
+end


### PR DESCRIPTION
Fixes #195.

## What changed

- Add `require_international_prefix: true` to require an explicit `+` or `00`.
- Add `format: :e164` for canonical `+`-prefixed E.164 input.
- Reuse parser prefix detection for consistent formatting and vanity-number behavior.
- Update the README and changelog, with regression coverage.